### PR TITLE
Fixed Subroutes on Main Page

### DIFF
--- a/src/fe-app/src/app/app.routes.ts
+++ b/src/fe-app/src/app/app.routes.ts
@@ -31,7 +31,17 @@ export const routes: Routes = [
   {
     path: 'main',
     component: MainComponent,
-    title: 'Main'
+    title: 'Main',
+    children: [
+      {
+        path: 'calendar',
+        component: CalendarComponent
+      },
+      {
+        path: 'task-list',
+        component: TaskListComponent
+      }
+    ]
   },
   {
     path: 'notifications',

--- a/src/fe-app/src/app/login/login.component.ts
+++ b/src/fe-app/src/app/login/login.component.ts
@@ -37,7 +37,7 @@ export class LoginComponent {
     .then((user: User | undefined) => {
       if (user && user.id) {
         this.user = user;
-        this.router.navigate(['/main']);
+        this.router.navigateByUrl("/main/task-list");
       }
     })
     .catch((error) => {
@@ -55,7 +55,7 @@ export class LoginComponent {
     .then((user: User) => {
       if (user) {
         this.user = user;
-        this.router.navigate(['/main']);
+        this.router.navigateByUrl("/main/task-list");
       } else {
         this.output = 'Login failed, please try again';
       }

--- a/src/fe-app/src/app/main/main.component.html
+++ b/src/fe-app/src/app/main/main.component.html
@@ -1,11 +1,9 @@
 <p>{{ this.output }}</p> <!-- to be removed -->
 <button (click)="getUserId()">UserId Tester</button> <!-- to be removed -->
 <button routerLink="/login">Back to Login</button>
-<!--<button routerLink="/settings">Settings</button>-->
+
 <button routerLink="/grades">Grades</button>
 <button routerLink="/main/add-task">TEST ADD TASK</button>
-
-
 
 
 <div class="main">
@@ -20,17 +18,12 @@
     <div class="task-info">
         <div class="view-select">
             <div class = "selectOptions">
-                <a href = "/calendar" ><h2>CALENDER</h2></a>
-                <a href = "/task-list"style = "width:100%"><h2>TASK-LIST</h2></a> <!--i know these don't do/go where we want yet just wanted to make them clickable-->
+                <a routerLink="calendar"><h2>CALENDER</h2></a>
+                <a routerLink="task-list" style="width:100%"><h2>TASK-LIST</h2></a>
             </div>
         </div>
         <div class="main-view">
-            @if (viewSelect === 0) {
-                <p>calendar view goes here</p>
-            }
-            @else if (viewSelect === 1) {
-                <app-task-list />
-            }
+            <router-outlet />
         </div>
     </div>
 </div>

--- a/src/fe-app/src/app/main/main.component.ts
+++ b/src/fe-app/src/app/main/main.component.ts
@@ -1,9 +1,9 @@
 import { Component, inject } from '@angular/core';
-import { RouterOutlet, RouterModule } from '@angular/router';
+import { Router, RouterOutlet, RouterModule } from '@angular/router';
+
 import { LoginService } from '../login.service';
 import { CoursesSidebarComponent } from "../main/courses-sidebar/courses-sidebar.component";
 import { DueSoonSidebarComponent } from '../main/due-soon-sidebar/due-soon-sidebar.component';
-import { TaskListComponent } from './task-list/task-list.component';
 
 
 const VIEW_CALENDAR: number = 0;
@@ -15,11 +15,20 @@ const VIEW_NOTIFICATIONS: number = 2; // This will not be necessary if I can get
     standalone: true,
     templateUrl: './main.component.html',
     styleUrl: './main.component.css',
-    imports: [RouterOutlet, RouterModule, CoursesSidebarComponent, DueSoonSidebarComponent, TaskListComponent]
+    imports: [RouterOutlet, RouterModule, CoursesSidebarComponent, DueSoonSidebarComponent]
 })
 export class MainComponent {
   loginService = inject(LoginService);
   output: string | null = ''; // to be removed for testing only
+
+  router = inject(Router);
+
+  // Redirect user to task-list if they are just in /main.
+  constructor() {
+    if (this.router.url != "/main/task-list" && this.router.url != "/main/calendar") {
+      this.router.navigateByUrl("/main/task-list");
+    }
+  }
 
   getUserId(): void { // function used just to test that we can access userId will be removed
     console.log(this.loginService.getUserId());


### PR DESCRIPTION
Added children property to "main" route including calendar and task-list so that clicking selectors no longer routes you to a page containing only these views. Also routes automatically to /main/task-list if the user navigates to only /main.