### PR TITLE
Fix Signals / Task List Not Updating on Add in Production

### DIFF
--- a/src/fe-app/src/app/assignment.service.ts
+++ b/src/fe-app/src/app/assignment.service.ts
@@ -1,5 +1,5 @@
 import { core } from '@angular/compiler';
-import { inject, Injectable, signal, WritableSignal } from '@angular/core';
+import { inject, Injectable, signal, WritableSignal, ChangeDetectorRef } from '@angular/core';
 
 import { LoginService } from './login.service';
 import { Assignment } from './course';
@@ -29,7 +29,7 @@ export class AssignmentService {
 
   // Returns assignment service's signal so that components may watch it for changes
   getUpdateSignal() {
-    return this.updateSignal;
+    return this.updateSignal();  // FUCK YOU
   }
 
   async getAssignments(userId: string | null): Promise<Assignment[]> {
@@ -112,7 +112,8 @@ export class AssignmentService {
         const assignment: Assignment = await response.json() ?? {};
 
         this.assignments.push(assignment);
-        this.updateSignal.set(++this.signalValue);  // Notify observing components that data has updated
+        this.updateSignal.set(100);  // Notify observing components that data has updated
+        // this.cdr.detectChanges();
       }
       catch (error: any) {
         console.error('Error adding task:', error);

--- a/src/fe-app/src/app/assignment.service.ts
+++ b/src/fe-app/src/app/assignment.service.ts
@@ -112,8 +112,7 @@ export class AssignmentService {
         const assignment: Assignment = await response.json() ?? {};
 
         this.assignments.push(assignment);
-        this.updateSignal.set(100);  // Notify observing components that data has updated
-        // this.cdr.detectChanges();
+        this.updateSignal.set(++this.signalValue);  // Notify observing components that data has updated
       }
       catch (error: any) {
         console.error('Error adding task:', error);

--- a/src/fe-app/src/app/main/calendar/calendar.component.ts
+++ b/src/fe-app/src/app/main/calendar/calendar.component.ts
@@ -33,7 +33,6 @@ export class CalendarComponent {
       const signal = this.assignmentService.getUpdateSignal();  // Referencing the signal is necessary for it to work
       console.log("COMPUTED SIGNAL RUN: Value " + signal);
       this.loadAssignments();                                   // Runs when service constructor finishes, no need to call twice
-      this.cdr.markForCheck();                                  // Explicitly mark for change detection checks
     })
   }
 

--- a/src/fe-app/src/app/main/calendar/calendar.component.ts
+++ b/src/fe-app/src/app/main/calendar/calendar.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, effect } from '@angular/core';
+import { Component, inject, ChangeDetectorRef, effect } from '@angular/core';
 
 import { LoginService } from '../../login.service';
 import { CourseService } from '../../course.service';
@@ -22,17 +22,18 @@ export class CalendarComponent {
 
   loginService = inject(LoginService);
   courseService = inject(CourseService);
-  assignmentService = inject(AssignmentService);
+  // assignmentService = inject(AssignmentService);
 
-  constructor() {
+  constructor(private assignmentService: AssignmentService, private cdr: ChangeDetectorRef) {
     this.weekStart = this.getWeekStart(new Date(Date.now()));
     this.pageNumber = 0;
 
     // Set logic to run whenever the AssignmentService signal updates (e.g. its constructor finishes or an assignment is added)
     effect(() => {
       const signal = this.assignmentService.getUpdateSignal();  // Referencing the signal is necessary for it to work
-      console.log("SIGNAL RUN: Value " + signal);
+      console.log("COMPUTED SIGNAL RUN: Value " + signal);
       this.loadAssignments();                                   // Runs when service constructor finishes, no need to call twice
+      this.cdr.markForCheck();                                  // Explicitly mark for change detection checks
     })
   }
 

--- a/src/fe-app/src/app/main/calendar/calendar.component.ts
+++ b/src/fe-app/src/app/main/calendar/calendar.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectorRef, effect } from '@angular/core';
+import { Component, inject, effect } from '@angular/core';
 
 import { LoginService } from '../../login.service';
 import { CourseService } from '../../course.service';
@@ -24,7 +24,7 @@ export class CalendarComponent {
   courseService = inject(CourseService);
   // assignmentService = inject(AssignmentService);
 
-  constructor(private assignmentService: AssignmentService, private cdr: ChangeDetectorRef) {
+  constructor(private assignmentService: AssignmentService) {
     this.weekStart = this.getWeekStart(new Date(Date.now()));
     this.pageNumber = 0;
 

--- a/src/fe-app/src/app/main/secondary-sidebar/secondary-sidebar.component.ts
+++ b/src/fe-app/src/app/main/secondary-sidebar/secondary-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Input, OnChanges, SimpleChanges, ChangeDetectorRef, effect } from '@angular/core';
+import { Component, inject, Input, OnChanges, SimpleChanges, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 
@@ -28,7 +28,7 @@ export class SecondarySidebarComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {}
 
-  constructor(private assignmentService: AssignmentService, private cdr: ChangeDetectorRef) {
+  constructor(private assignmentService: AssignmentService) {
     this.courseService.getCourses(this.loginService.getUserId())
     .then((courses: Course[]) => {
       this.courses = courses;

--- a/src/fe-app/src/app/main/secondary-sidebar/secondary-sidebar.component.ts
+++ b/src/fe-app/src/app/main/secondary-sidebar/secondary-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Input, OnChanges, SimpleChanges, effect } from '@angular/core';
+import { Component, inject, Input, OnChanges, SimpleChanges, ChangeDetectorRef, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 
@@ -22,13 +22,13 @@ export class SecondarySidebarComponent implements OnChanges {
 
   loginService = inject(LoginService)
   courseService = inject(CourseService);
-  assignmentService = inject(AssignmentService);
+  // assignmentService = inject(AssignmentService);
   gradesService = inject(GradesService);
   router = inject(Router);
 
   ngOnChanges(changes: SimpleChanges) {}
 
-  constructor() {
+  constructor(private assignmentService: AssignmentService, private cdr: ChangeDetectorRef) {
     this.courseService.getCourses(this.loginService.getUserId())
     .then((courses: Course[]) => {
       this.courses = courses;
@@ -37,11 +37,12 @@ export class SecondarySidebarComponent implements OnChanges {
     // Set logic to run whenever the AssignmentService signal updates (e.g. its constructor finishes or an assignment is added)
     effect(() => {
       const signal = this.assignmentService.getUpdateSignal();  // Referencing the signal is necessary for it to work
-      console.log("SIGNAL RUN: Value " + signal);
+      console.log("COMPUTED SIGNAL RUN: Value " + signal);
       // Runs when service constructor finishes, no need to call twice
       this.assignmentService.getAssignments(this.loginService.getUserId()).then((assignments: Assignment[]) => {
         this.filterTopThree(assignments)
-      })
+      });
+      this.cdr.markForCheck();  // Explicitly mark for change detection checks
     })
 
     this.gradesService.getGrades(this.loginService.getUserId())

--- a/src/fe-app/src/app/main/secondary-sidebar/secondary-sidebar.component.ts
+++ b/src/fe-app/src/app/main/secondary-sidebar/secondary-sidebar.component.ts
@@ -42,7 +42,6 @@ export class SecondarySidebarComponent implements OnChanges {
       this.assignmentService.getAssignments(this.loginService.getUserId()).then((assignments: Assignment[]) => {
         this.filterTopThree(assignments)
       });
-      this.cdr.markForCheck();  // Explicitly mark for change detection checks
     })
 
     this.gradesService.getGrades(this.loginService.getUserId())

--- a/src/fe-app/src/app/main/task-list/task-list.component.ts
+++ b/src/fe-app/src/app/main/task-list/task-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, inject, Output, OnInit, Input, SimpleChanges, ChangeDetectorRef, effect } from '@angular/core';
+import { Component, inject, Input, SimpleChanges, ChangeDetectorRef, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 

--- a/src/fe-app/src/app/main/task-list/task-list.component.ts
+++ b/src/fe-app/src/app/main/task-list/task-list.component.ts
@@ -43,7 +43,6 @@ export class TaskListComponent{
       const signal = this.assignmentService.getUpdateSignal();  // Referencing the signal is necessary for it to work
       console.log("SIGNAL RUN: Value " + signal);
       this.loadAssignments();                                   // Runs when service constructor finishes, no need to call twice
-      this.cdr.markForCheck();                                  // Explicitly mark for change detection checks
     })
   }
 


### PR DESCRIPTION
Note: can simulate a production environment in Angular (most importantly, lazy evaluation of signals) by using `ng serve --configuration=production` in the command line. Finishes mandatory fixes for #315 