### PR TITLE
Improved Error Checking in Services

### DIFF
--- a/src/fe-app/src/app/assignment.service.ts
+++ b/src/fe-app/src/app/assignment.service.ts
@@ -51,8 +51,12 @@ export class AssignmentService {
       }
       return data;
     }
-    catch (error: any) {
-      console.error('Error fetching assignments:', error);
+    catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error fetching assignments:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
       throw error;
     }
  }
@@ -77,8 +81,12 @@ export class AssignmentService {
       console.log(data);
       return data;
     }
-    catch (error: any) {
-      console.error('Error fetching assignment:', error);
+    catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error fetching assignment:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
       throw error;
     }
   }
@@ -114,8 +122,12 @@ export class AssignmentService {
         this.assignments.push(assignment);
         this.updateSignal.set(++this.signalValue);  // Notify observing components that data has updated
       }
-      catch (error: any) {
-        console.error('Error adding task:', error);
+      catch (error: unknown) {
+        if (error instanceof Error) {
+          console.error('Error adding task:', error.message);
+        } else {
+          console.error('Unexpected error', error);
+        }
         throw error;
       }
   }
@@ -142,8 +154,12 @@ export class AssignmentService {
       }
 
       console.log(response);
-    } catch (error: any) {
-      console.error('Error editing task:', error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error editing task:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
       throw error;
     }
   }
@@ -164,8 +180,12 @@ export class AssignmentService {
       }
 
       console.log(response);
-    } catch (error: any) {
-      console.error('Error completing task:', error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error completing task:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
       throw error;
     }
   }
@@ -186,8 +206,12 @@ export class AssignmentService {
       }
 
       console.log(response);
-    } catch (error: any) {
-      console.error('Error opening task:', error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error opening task:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
       throw error;
     }
   }
@@ -206,8 +230,12 @@ export class AssignmentService {
         throw new Error(`DELETE failed: ${response.status}`)
       }
 
-    } catch(error: any) {
-      console.error('Error removing task: ', error);
+    } catch(error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error removing task:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
       throw error;
     }
   }

--- a/src/fe-app/src/app/course.service.ts
+++ b/src/fe-app/src/app/course.service.ts
@@ -24,8 +24,12 @@ export class CourseService {
 
       console.log(data);
       return data;
-    } catch (error: any) {
-      console.error('Error fetching courses:', error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error fetching courses:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
       throw error;
     }
   }
@@ -41,8 +45,12 @@ export class CourseService {
 
       console.log(data);
       return data;
-    } catch (error: any) {
-      console.error('Error fetching course:', error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error fetching course:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
       throw error;
     }
   }

--- a/src/fe-app/src/app/grades.service.ts
+++ b/src/fe-app/src/app/grades.service.ts
@@ -19,8 +19,12 @@ export class GradesService {
 
     console.log(data);
     return data;
-  } catch (error: any) {
-    console.error('Error fetching assignments:', error);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error('Error fetching assignments:', error.message);
+    } else {
+      console.error('Unexpected error', error);
+    }
     throw error;
   }
 
@@ -42,8 +46,12 @@ export class GradesService {
         }
 
         console.log(response);
-      } catch (error: any) {
-        console.error('Error setting grade:', error);
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          console.error('Error setting grade:', error.message);
+        } else {
+          console.error('Unexpected error', error);
+        }
         throw error;
       }
   }

--- a/src/fe-app/src/app/heartbeat.service.ts
+++ b/src/fe-app/src/app/heartbeat.service.ts
@@ -76,8 +76,12 @@ export class HeartbeatService {
       }
 
       //console.log(response);
-    } catch (error: any) {
-      console.error('Error sending heartbeat:', error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error sending heartbeat:', error.message); // network error
+      } else {
+        console.error('Unexpected error', error); // unexpected error
+      }
       throw error;
     }
   }

--- a/src/fe-app/src/app/login.service.spec.ts
+++ b/src/fe-app/src/app/login.service.spec.ts
@@ -37,6 +37,14 @@ describe('LoginService', () => {
       .toBeRejectedWithError('Network Error');
   });
 
+  // example unexpected error test
+  // it('should throw and log an unexpected error when login fails with an unknown error type', async () => {
+  //   spyOn(window, 'fetch').and.returnValue(Promise.reject(123));
+
+  //   await expectAsync(service.login('username', 'password'))
+  //     .toBeRejectedWith(123);
+  // });
+
   it('should successfully log in a user', async () => {
     const mockUser: User = { id: '123'};
 

--- a/src/fe-app/src/app/login.service.ts
+++ b/src/fe-app/src/app/login.service.ts
@@ -26,7 +26,7 @@ export class LoginService {
       });
 
       if(!response.ok) {
-        throw new Error(`POST failed: ${response.status}`)
+        throw new Error(`POST failed: ${response.status}`) // response error
       }
 
       const user: Promise<User> = await response.json() ?? {};
@@ -35,8 +35,12 @@ export class LoginService {
       console.log(user);
 
       return user;
-    } catch (error: any) {
-      console.error('Error logging in:', error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error logging in:', error.message); // network error
+      } else {
+        console.error('Unexpected error', error); // unexpected error
+      }
       throw error;
     }
   }

--- a/src/fe-app/src/app/settings.service.ts
+++ b/src/fe-app/src/app/settings.service.ts
@@ -20,8 +20,12 @@ export class SettingsService {
 
     console.log(data);
     return data;
-  } catch (error: any) {
-    console.error('Error fetching userInfo:', error);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error('Error fetching userInfo:', error.message);
+    } else {
+      console.error('Unexpected error', error);
+    }
     throw error;
   }
 
@@ -43,8 +47,12 @@ export class SettingsService {
       }
       console.log(response);
     }
-    catch (error: any) {
-      console.error('Error updating notification settings:', error);
+    catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error updating notification settings:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
       throw error;
     }
   }
@@ -64,8 +72,12 @@ export class SettingsService {
       }
       console.log(response);
     }
-    catch (error: any) {
-      console.error('Error updating Preferred Name:', error);
+    catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error updating preferred name:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
       throw error;
     }
   }
@@ -85,8 +97,12 @@ export class SettingsService {
       }
       console.log(response);
     }
-    catch (error: any) {
-      console.error('Error updating Email:', error);
+    catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error updating Email:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
       throw error;
     }
   }
@@ -106,8 +122,12 @@ export class SettingsService {
       }
       console.log(response);
     }
-    catch (error: any) {
-      console.error('Error updating Phone Number:', error);
+    catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error updating Phone Number:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
       throw error;
     }
   }


### PR DESCRIPTION
Initially intended to use HttpError to check errors from API calls, but would need to use HttpClient instead of fetches to use this error type which would require an extensive overhaul of every service and how we use them in the components. HttpError would handle all types of errors for us. 

When using any in the catch block as the error type any error expected or unexpected would be considered a network failure due to type Error. To combat confusion of error types we manually check the response status and throw errors if not `ok`. Then, in the catch block we check for type error to determine it is a network error or if not of type Error it is something unexpected which would require further debugging. 

HttpError would have handled all this for us in one catch block but the need to overhaul the entire service when manual checking can provide us a similar result seemed to suffice.