### PR TITLE
Infinitely Scrollable Calendar Logic

### DIFF
--- a/src/fe-app/src/app/main/calendar/calendar.component.html
+++ b/src/fe-app/src/app/main/calendar/calendar.component.html
@@ -77,13 +77,13 @@
 <!-- TODO Make buttons icons rather than text -->
 <div class="page-container">
     <div id="lastWeekButton">
-        <button (click)="pageBack()">Previous Week</button>
+        <button (click)="pageBack()" [disabled]="this.checkSemesterStart(this.weekStart)">Previous Week</button>
     </div>
     <div id="resetButton">
         <button (click)="reset()" [disabled]="this.pageNumber == 0">Reset</button>
     </div>
     <div id="nextWeekButton">
-        <button (click)="pageForward()">Next Week</button>
+        <button (click)="pageForward()" [disabled]="this.checkSemesterEnd(this.weekStart)">Next Week</button>
     </div>
 </div>
 

--- a/src/fe-app/src/app/main/calendar/calendar.component.html
+++ b/src/fe-app/src/app/main/calendar/calendar.component.html
@@ -1,4 +1,4 @@
-<h1>CALENDAR</h1>
+<h1>Week of {{this.weekStart}}</h1>
 <div class="calendar-container">
     <br><div class="day">MONDAY</div>
     <div class="calendar-element">
@@ -76,12 +76,14 @@
 
 <!-- TODO Make buttons icons rather than text -->
 <div class="page-container">
-    <div id = "lastWeekButton">
-        <button (click)="pageBack()" [disabled]="this.pageNumber <= 0">Last Week</button>
+    <div id="lastWeekButton">
+        <button (click)="pageBack()">Previous Week</button>
     </div>
-    <p>{{ this.pageNumber }}</p>
-    <div id = "nextWeekButton">
-        <button (click)="pageForward()" [disabled]="this.pageNumber >= 3">Next Week</button>
+    <div id="resetButton">
+        <button (click)="reset()" [disabled]="this.pageNumber == 0">Reset</button>
+    </div>
+    <div id="nextWeekButton">
+        <button (click)="pageForward()">Next Week</button>
     </div>
 </div>
 

--- a/src/fe-app/src/app/main/calendar/calendar.component.html
+++ b/src/fe-app/src/app/main/calendar/calendar.component.html
@@ -1,4 +1,4 @@
-<h1>Week of {{this.weekStart}}</h1>
+<h1>Week of {{ this.formatDate(this.weekStart) }}</h1>
 <div class="calendar-container">
     <br><div class="day">MONDAY</div>
     <div class="calendar-element">

--- a/src/fe-app/src/app/main/calendar/calendar.component.ts
+++ b/src/fe-app/src/app/main/calendar/calendar.component.ts
@@ -80,13 +80,11 @@ export class CalendarComponent {
     for (const assignment of this.assignments) {
       const difference = assignment.availability.adaptiveRelease.end.getTime() - this.weekStart.getTime();
 
-      // Ignore options out of range (can break if too high because array was sorted in constructor)
+      // Add assignment to array if it's in range based on the day it falls into
       if (difference < 0)
         continue;
       if (difference >= 7 * millisecondsPerDay)
         break;
-
-      // Add assignment to array if it's in range based on the day it falls into
       this.weekAssignments[difference / millisecondsPerDay].push(assignment);
     }
   }
@@ -98,6 +96,8 @@ export class CalendarComponent {
     this.weekStart.setDate(this.weekStart.getDate() + 7);
     this.pageNumber++;
     this.organizeWeekAssignments();
+
+    console.log("WEEK START TEST: " + this.weekStart);
   }
 
   /**
@@ -116,6 +116,27 @@ export class CalendarComponent {
     this.weekStart = this.getWeekStart(new Date(Date.now()));
     this.pageNumber = 0;
     this.organizeWeekAssignments();
+  }
+
+  /**
+   * Format the given date in the format of "<Month> <Day>[st/nd/rd/th]"
+   * @param date The date to format
+   * @return Formatted string with relevant date information.
+   */
+  formatDate(date: Date) {
+    let output: String = date.toLocaleString('en-US', {month: "long", day: "numeric"})
+
+    // ugh
+    if (this.weekStart.getDate() % 10 == 1 && this.weekStart.getDate() != 11)
+      output += "st"
+    else if (this.weekStart.getDate() % 10 == 2 && this.weekStart.getDate() != 12)
+      output += "nd"
+    else if (this.weekStart.getDate() % 10 == 3 && this.weekStart.getDate() != 13)
+      output += "rd"
+    else
+      output += "th"
+
+    return output;
   }
 
   // TODO implement logic to disable previous/next buttons at beginning/end of semester

--- a/src/fe-app/src/app/main/calendar/calendar.component.ts
+++ b/src/fe-app/src/app/main/calendar/calendar.component.ts
@@ -35,8 +35,9 @@ export class CalendarComponent {
       console.log("COMPUTED SIGNAL RUN: Value " + signal);
 
       // Runs when service constructor finishes, no need to call twice
-      this.loadAssignments();
-      this.organizeWeekAssignments();
+      this.loadAssignments().then(() => {
+        this.organizeWeekAssignments();
+      });
     })
   }
 
@@ -45,6 +46,7 @@ export class CalendarComponent {
    */
   async loadAssignments() {
     this.assignments = await this.assignmentService.getAssignments(this.loginService.getUserId());
+    console.log("TEST ASSIGNMENTS:" + this.assignments);
 
     // Turn assignment date strings into date objects and sort entire list by date
     for (let assignment of this.assignments) {
@@ -115,4 +117,6 @@ export class CalendarComponent {
     this.pageNumber = 0;
     this.organizeWeekAssignments();
   }
+
+  // TODO implement logic to disable previous/next buttons at beginning/end of semester
 }

--- a/src/fe-app/src/app/main/calendar/calendar.component.ts
+++ b/src/fe-app/src/app/main/calendar/calendar.component.ts
@@ -47,13 +47,9 @@ export class CalendarComponent {
     this.semesterEnd = this.getWeekStart(this.semesterEnd);
     this.semesterEnd.setDate(this.semesterEnd.getDate() + 7);
 
-    console.log("SEMESTER START: " + this.semesterStart);
-    console.log("SEMESTER END: " + this.semesterEnd);
-
     // Set logic to run whenever the AssignmentService signal updates (e.g. its constructor finishes or an assignment is added)
     effect(() => {
       const signal = this.assignmentService.getUpdateSignal();  // Referencing the signal is necessary for it to work
-      console.log("COMPUTED SIGNAL RUN: Value " + signal);
 
       // Runs when service constructor finishes, no need to call twice
       this.loadAssignments().then(() => {
@@ -67,7 +63,6 @@ export class CalendarComponent {
    */
   async loadAssignments() {
     this.assignments = await this.assignmentService.getAssignments(this.loginService.getUserId());
-    console.log("TEST ASSIGNMENTS:" + this.assignments);
 
     // Turn assignment date strings into date objects and sort entire list by date
     for (let assignment of this.assignments) {


### PR DESCRIPTION
Opening this now and marking it as a draft shortly to showcase progress. Most of it is done functionality-wise, including:
- Removed calendar bounds so that weeks can be navigated infinitely
- Added a reset button to return user to the current week (disabled when on current week)
- Replaced page number indicator with a "Week of <Date>" in calendar header
- Slightly refactored some stuff so there was less overhead for any future changes

Currently looking at:
- Implementing boundaries for when there are no more assignments left in a direction and/or an end of the current semester is encountered
- Anchoring calendar header and navigation buttons so that they are always available even when the calendar itself requires scrolling
- Replacing back/forward text on buttons with arrow icons

Other feedback is appreciated -- let me know if you would prefer me to take care of anchoring in the current branch or if you'd like me to merge so that someone else can take care of the anchoring. When finished, this will close issues #245 and #361.