### PR TITLE
Update Password

### DIFF
--- a/src/fe-app/src/app/settings.service.ts
+++ b/src/fe-app/src/app/settings.service.ts
@@ -9,7 +9,11 @@ export class SettingsService {
 
   constructor() { }
 
-  // potentially verify if userId matches one received
+  /**
+   * Retrieves all necessary user info for use in settings pages
+   * @param userId The ID of the desired user, will typically be the user currently logged in
+   * @returns User info, including settings, as a UserInfo object
+   */
   async getUserInfo(userId: string | null): Promise<UserInfo> {
     const response = await fetch(`${this.url}getUser?userId=${userId}`);
     const data = await response.json() ?? {};
@@ -29,6 +33,11 @@ export class SettingsService {
     throw error;
   }
 
+  /**
+   * Updates the preferred name of the desired user within classMATE
+   * @param userId The ID of the desired user, will typically be the user currently logged in
+   * @param updatedName New preferred name
+   */
   async updatePreferredName(userId: string | null, updatedName: string | null): Promise<void> {
     const queryParams = new URLSearchParams({
       userId: userId ?? "NULL",
@@ -54,6 +63,11 @@ export class SettingsService {
     }
   }
 
+  /**
+   * Updates the personal email of the desired user within classMATE
+   * @param userId The ID of the desired user, will typically be the user currently logged in
+   * @param updatedEmail New personal email
+   */
   async updatePersonalEmail(userId: string | null, updatedEmail: string | null): Promise<void> {
     const queryParams = new URLSearchParams({
       userId: userId ?? "NULL",
@@ -79,10 +93,15 @@ export class SettingsService {
     }
   }
 
-  async updatePhoneNumber(userId: string | null, updatedName: string | null): Promise<void> {
+  /**
+   * Updates the phone number used for text notifications of the desired user
+   * @param userId The ID of the desired user, will typically be the user currently logged in
+   * @param updatedPhone New phone number
+   */
+  async updatePhoneNumber(userId: string | null, updatedPhone: string | null): Promise<void> {
     const queryParams = new URLSearchParams({
       userId: userId ?? "NULL",
-      phoneNumber: updatedName ?? "NULL"
+      phoneNumber: updatedPhone ?? "NULL"
     }).toString();
 
     try {
@@ -104,6 +123,12 @@ export class SettingsService {
     }
   }
 
+  /**
+   * Updates password of the desired user, using their current password as authorization
+   * @param userId The ID of the desired user, will typically be the user currently logged in
+   * @param currentPassword Current password of the desired user
+   * @param newPassword Updated password
+   */
   async updatePassword(userId: string | null, currentPassword: string | null, newPassword: string | null): Promise<void> {
     const queryParams = new URLSearchParams({
       userId: userId ?? "NULL",
@@ -133,6 +158,13 @@ export class SettingsService {
     }
   }
 
+  /**
+   * Updates the notification settings of the desired user
+   * @param userId The ID of the desired user, will typically be the user currently logged in
+   * @param schoolEmail School email notifications, true if enabled
+   * @param personalEmail Personal email notifications, true if enabled
+   * @param sms Text notifications, true if enabled
+   */
   async updateNotificationSettings(userId: string | null, schoolEmail: boolean, personalEmail: boolean, sms: boolean): Promise<void> {
     const queryParams = new URLSearchParams({
       userId: userId ?? "NULL",

--- a/src/fe-app/src/app/settings.service.ts
+++ b/src/fe-app/src/app/settings.service.ts
@@ -29,34 +29,6 @@ export class SettingsService {
     throw error;
   }
 
-  async updateNotificationSettings(userId: string | null, schoolEmail: boolean, personalEmail: boolean, sms: boolean): Promise<void> {
-    const queryParams = new URLSearchParams({
-      userId: userId ?? "NULL",
-      email: String(personalEmail) ?? "NULL",
-      sms: String(sms) ?? "NULL",
-      institutionEmail: String(schoolEmail) ?? "NULL"
-    }).toString();
-
-    try {
-      const response = await fetch(`${this.url}updateNotificationSettings?${queryParams}`, {
-        method: 'POST'
-      });
-
-      if(!response.ok) {
-        throw new Error(`POST failed: ${response.status}`);
-      }
-      console.log(response);
-    }
-    catch (error: unknown) {
-      if (error instanceof Error) {
-        console.error('Error updating notification settings:', error.message);
-      } else {
-        console.error('Unexpected error', error);
-      }
-      throw error;
-    }
-  }
-
   async updatePreferredName(userId: string | null, updatedName: string | null): Promise<void> {
     const queryParams = new URLSearchParams({
       userId: userId ?? "NULL",
@@ -125,6 +97,62 @@ export class SettingsService {
     catch (error: unknown) {
       if (error instanceof Error) {
         console.error('Error updating Phone Number:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
+      throw error;
+    }
+  }
+
+  async updatePassword(userId: string | null, currentPassword: string | null, newPassword: string | null): Promise<void> {
+    const queryParams = new URLSearchParams({
+      userId: userId ?? "NULL",
+      oldPassword: currentPassword ?? "NULL",
+      newPassword: newPassword ?? "NULL"
+    }).toString();
+
+    console.log("attempting password update with values " + currentPassword + ", " + newPassword);
+
+    try {
+      const response = await fetch (`${this.url}editPassword?${queryParams}`, {
+        method: 'PUT'
+      });
+      if(!response.ok) {
+        throw new Error(`POST failed: ${response.status}`);
+      }
+      console.log(response);
+    }
+    catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error updating password: ', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
+      throw error;
+    }
+  }
+
+  async updateNotificationSettings(userId: string | null, schoolEmail: boolean, personalEmail: boolean, sms: boolean): Promise<void> {
+    const queryParams = new URLSearchParams({
+      userId: userId ?? "NULL",
+      email: String(personalEmail) ?? "NULL",
+      sms: String(sms) ?? "NULL",
+      institutionEmail: String(schoolEmail) ?? "NULL"
+    }).toString();
+
+    try {
+      const response = await fetch(`${this.url}updateNotificationSettings?${queryParams}`, {
+        method: 'POST'
+      });
+
+      if(!response.ok) {
+        throw new Error(`POST failed: ${response.status}`);
+      }
+      console.log(response);
+    }
+    catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error updating notification settings:', error.message);
       } else {
         console.error('Unexpected error', error);
       }

--- a/src/fe-app/src/app/settings.service.ts
+++ b/src/fe-app/src/app/settings.service.ts
@@ -114,20 +114,21 @@ export class SettingsService {
     console.log("attempting password update with values " + currentPassword + ", " + newPassword);
 
     try {
-      const response = await fetch (`${this.url}editPassword?${queryParams}`, {
+      const response = await fetch(`${this.url}editPassword?${queryParams}`, {
         method: 'PUT'
       });
+
       if(!response.ok) {
-        throw new Error(`POST failed: ${response.status}`);
+        console.log("DEBUG: ERROR UPDATING PASSWORD (SettingsService::updatePassword)");
+        throw new Error(await response.text());
       }
-      console.log(response);
     }
     catch (error: unknown) {
-      if (error instanceof Error) {
+      console.log("DEBUG 2: ERROR UPDATING PASSWORD (SettingsService::updatePassword -> catch)");
+      if (error instanceof Error)
         console.error('Error updating password: ', error.message);
-      } else {
+      else
         console.error('Unexpected error', error);
-      }
       throw error;
     }
   }

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.css
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.css
@@ -23,8 +23,32 @@ button {
     margin-left: 10px;
 }
 
+.link {
+    margin-top: 10px;
+    font-size: 14px;
+    color: #800000;
+}
+
+.overlay {
+    position: fixed;
+    top: 0; left: 0; width: 100%; height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+}
+  
+.popup {
+    position: fixed;
+    top: 50%; left: 50%;
+    transform: translate(-50%, -50%);
+    background: white;
+    padding: 20px;
+    border-radius: 10px;
+    box-shadow: 0px 0px 10px #000;
+    text-align: center;
+}
+
 .save-close {
     display: flex;
+    justify-content: center;
 }
 
 .error {

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.css
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.css
@@ -24,9 +24,15 @@ button {
 }
 
 .link {
-    margin-top: 10px;
+    margin: 10px 0px 0px 0px;
     font-size: 14px;
     color: #800000;
+}
+
+.success {
+    margin: 10px 0px 0px 0px;
+    font-size: 14px;
+    color: #454545;
 }
 
 .overlay {

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.css
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.css
@@ -26,3 +26,7 @@ button {
 .save-close {
     display: flex;
 }
+
+.error {
+    color: red;
+}

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.css
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.css
@@ -22,3 +22,7 @@ button {
     margin-top: 20px;
     margin-left: 10px;
 }
+
+.save-close {
+    display: flex;
+}

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
@@ -42,6 +42,10 @@
         </div>
     }
 
-    <button type="submit" [disabled]="!this.profileForm.valid">Save</button>
+    <button type="submit" [disabled]="!this.profileForm.valid || !this.checkForChanges()">Save</button>
+
+    @if (this.profileConfirm) {
+        <p>Profile settings saved!</p>
+    }
 </form>
 

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
@@ -11,7 +11,13 @@
     <label for="phone-number">Phone Number:</label>
     <input type="tel" id="phone-number" formControlName="phone"/>
 
-    <a class="link" (click)="callPasswordWindow(true)">Update Password</a>
+    @if (this.passwordConfirm) {
+        <p class="success">Password successfully updated!</p>
+    }
+    @else {
+        <a class="link" (click)="callPasswordWindow(true)">Update Password</a>
+    }
+
     @if(this.viewPassword) {
         
         <div class="overlay">

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
@@ -11,6 +11,24 @@
     <label for="phone-number">Phone Number:</label>
     <input type="tel" id="phone-number" formControlName="phone"/>
 
+    <a (click)="callPasswordWindow(true)">Update Password</a>
+    @if(this.viewPassword) {
+        <!-- Enter current password to validate? -->
+        
+        <label for="password">New Password:</label>
+        <input type="password" id="password" formControlName="password" />
+
+        <label for="password-re">Retype Password:</label>
+        <input type="password" id="password-re" formControlName="passwordRetype" />
+
+        <div class="save-close">
+            <button (click)="callPasswordWindow(false)">Close</button>
+            <button (click)="attemptPasswordSave()">Save</button>
+        </div>
+
+        <p>TODO make popup</p>
+    }
+
     <button type="submit" [disabled]="!this.profileForm.valid">Save</button>
 </form>
 

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
@@ -45,7 +45,7 @@
     <button type="submit" [disabled]="!this.profileForm.valid || !this.checkForChanges()">Save</button>
 
     @if (this.profileConfirm) {
-        <p>Profile settings saved!</p>
+        <p class="success">Profile settings saved!</p>
     }
 </form>
 

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
@@ -11,27 +11,29 @@
     <label for="phone-number">Phone Number:</label>
     <input type="tel" id="phone-number" formControlName="phone"/>
 
-    <a (click)="callPasswordWindow(true)">Update Password</a>
+    <a class="link" (click)="callPasswordWindow(true)">Update Password</a>
     @if(this.viewPassword) {
-        <!-- Enter current password to validate? -->
         
-        <labeL for="password">Current Password:</labeL>
-        <input type="password" id="password" formControlName="password" />
+        <div class="overlay">
+            <div class="popup">
+                <labeL for="password">Current Password:</labeL>
+                <input type="password" id="password" formControlName="password" />
 
-        <label for="new-password">New Password:</label>
-        <input type="password" id="new-password" formControlName="newPassword" />
+                <label for="new-password">New Password:</label>
+                <input type="password" id="new-password" formControlName="newPassword" />
 
-        <label for="password-re">Retype Password:</label>
-        <input type="password" id="password-re" formControlName="passwordRetype" />
+                <label for="password-re">Retype Password:</label>
+                <input type="password" id="password-re" formControlName="passwordRetype" />
 
-        <p class="error">{{ this.passwordError }}</p>
+                <p class="error">{{ this.passwordError }}</p>
 
-        <div class="save-close">
-            <button (click)="callPasswordWindow(false)">Close</button>
-            <button (click)="attemptPasswordSave()">Save</button>
+                <div class="save-close">
+                    <button (click)="callPasswordWindow(false)">Close</button>
+                    <button (click)="attemptPasswordSave()">Save</button>
+                </div>
+
+            </div>
         </div>
-
-        <p>TODO make popup</p>
     }
 
     <button type="submit" [disabled]="!this.profileForm.valid">Save</button>

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
@@ -11,12 +11,15 @@
     <label for="phone-number">Phone Number:</label>
     <input type="tel" id="phone-number" formControlName="phone"/>
 
+    <!--
     @if (this.passwordConfirm) {
         <p class="success">Password successfully updated!</p>
     }
     @else {
         <a class="link" (click)="callPasswordWindow(true)">Update Password</a>
     }
+    -->
+    <a class="link" (click)="callPasswordWindow(true)">Update Password</a>
 
     @if(this.viewPassword) {
         
@@ -31,8 +34,10 @@
                 <label for="password-re">Retype Password:</label>
                 <input type="password" id="password-re" formControlName="passwordRetype" />
 
+                <!--
                 <p class="error">{{ this.passwordError }}</p>
-
+                -->
+                
                 <div class="save-close">
                     <button (click)="callPasswordWindow(false)">Close</button>
                     <button (click)="attemptPasswordSave()">Save</button>

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.html
@@ -15,11 +15,16 @@
     @if(this.viewPassword) {
         <!-- Enter current password to validate? -->
         
-        <label for="password">New Password:</label>
+        <labeL for="password">Current Password:</labeL>
         <input type="password" id="password" formControlName="password" />
+
+        <label for="new-password">New Password:</label>
+        <input type="password" id="new-password" formControlName="newPassword" />
 
         <label for="password-re">Retype Password:</label>
         <input type="password" id="password-re" formControlName="passwordRetype" />
+
+        <p class="error">{{ this.passwordError }}</p>
 
         <div class="save-close">
             <button (click)="callPasswordWindow(false)">Close</button>

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.spec.ts
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.spec.ts
@@ -32,7 +32,7 @@ describe('ProfileSettingsComponent', () => {
   const MOCK_PHONE_AUGMENTED = "012-345-6789"
 
   beforeEach(async () => {
-    
+
     // Note: object notation in createSpyObj() is similar to list but allows mock return values to be defined alongside spy object
     mockLoginService = jasmine.createSpyObj(LoginService, { getUserId: MOCK_USER_INFO.id });
     mockSettingsService = jasmine.createSpyObj(SettingsService, {
@@ -41,7 +41,7 @@ describe('ProfileSettingsComponent', () => {
       updatePersonalEmail: undefined,
       updatePhoneNumber: undefined
     });
-    
+
     await TestBed.configureTestingModule({
       imports: [ProfileSettingsComponent],
       providers: [
@@ -75,13 +75,30 @@ describe('ProfileSettingsComponent', () => {
   // Clicking save button should call component's saveProfile() method
   it('should call component.saveProfile() when button is clicked', async () => {
     spyOn(component, 'saveProfile');
+    fixture.detectChanges(); // Ensure component initializes properly
+
+    // Fill the form with valid data to ensure the button is enabled
+    component.profileForm.setValue({
+      name: "Michael",
+      school: "michael@sc.edu",
+      personal: "michael@gmail.com",
+      phone: "555-555-5555",
+      password: "",
+      newPassword: "",
+      passwordRetype: ""
+    });
+
+    fixture.detectChanges(); // Trigger UI update
+
     await fixture.whenStable();
-    fixture.detectChanges();
 
     const submitButton = fixture.debugElement.nativeElement.querySelector('button[type="submit"]');
-    submitButton.click();
 
-    expect(submitButton.disabled).toBeFalse();
+    expect(submitButton.disabled).toBeFalse(); // Ensure it's clickable
+
+    submitButton.click();
+    fixture.detectChanges(); // Allow Angular to process event
+
     expect(component.saveProfile).toHaveBeenCalledOnceWith();
   })
 

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
@@ -20,9 +20,9 @@ export class ProfileSettingsComponent {
   personalEmail: string = "";
   phoneNumber: string = "";
 
-  password: string = "";
-  passwordRetype: string = "";
   viewPassword: boolean = false;
+  passwordError: string = "";
+  passwordConfirm: boolean = false;
 
   loginService = inject(LoginService);
   settingsService = inject(SettingsService);
@@ -33,6 +33,7 @@ export class ProfileSettingsComponent {
     personal: new FormControl("", [Validators.required, Validators.email]),
     phone: new FormControl("", [Validators.required, Validators.pattern("[0-9]{3}-?[0-9]{3}-?[0-9]{4}")]),
     password: new FormControl(""),
+    newPassword: new FormControl(""),
     passwordRetype: new FormControl("")
   });
 
@@ -53,8 +54,9 @@ export class ProfileSettingsComponent {
         school: this.schoolEmail,
         personal: this.personalEmail,
         phone: this.phoneNumber,
-        password: this.password,
-        passwordRetype: this.passwordRetype
+        password: "",
+        newPassword: "",
+        passwordRetype: ""
       })
     })
   }
@@ -74,6 +76,27 @@ export class ProfileSettingsComponent {
    */
   attemptPasswordSave() {
     console.log("Save password");
+
+    if (this.profileForm.value.newPassword != this.profileForm.value.passwordRetype) {
+      this.passwordError = "Passwords do not match"
+      return
+    }
+
+    // TODO decide on inherent password conditions and implement
+    if (false) {
+      this.passwordError = "TODO";
+      return;
+    }
+
+
+    // Note: "as string | null" is necessary because typescript randomly allows it to also be undefined and it ruins everything 
+    this.settingsService.updatePassword(
+      this.loginService.getUserId(),
+      this.profileForm.value.password as string | null,
+      this.profileForm.value.newPassword as string | null
+    );
+
+    // TODO handle request errors
 
     this.callPasswordWindow(false);
   }

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
@@ -74,7 +74,7 @@ export class ProfileSettingsComponent {
   /**
    * Attempts to save the user's new password by validating the entry and making the necessary service calls.
    */
-  attemptPasswordSave() {
+  async attemptPasswordSave() {
     console.log("Save password");
 
     if (this.profileForm.value.newPassword != this.profileForm.value.passwordRetype) {
@@ -82,22 +82,22 @@ export class ProfileSettingsComponent {
       return
     }
 
-    // TODO decide on inherent password conditions and implement
-    if (false) {
-      this.passwordError = "TODO";
-      return;
+    // Note: "as string | null" is necessary because typescript randomly allows it to also be undefined and it ruins everything
+    const oldPassword = this.profileForm.value.password as string | null;
+    const newPassword = this.profileForm.value.newPassword as string | null;
+    try {
+      await this.settingsService.updatePassword(this.loginService.getUserId(), oldPassword, newPassword);
+    }
+    catch (error: unknown) {
+      console.log("DEBUG 3: ERROR UPDATING PASSWORD (ProfileSettingsComponent::attemptPasswordSave)");
+      if (error instanceof Error)
+        this.passwordError = error.message;
+      else
+        this.passwordError = "Unexpected error, please try again later";
+      return
     }
 
-
-    // Note: "as string | null" is necessary because typescript randomly allows it to also be undefined and it ruins everything 
-    this.settingsService.updatePassword(
-      this.loginService.getUserId(),
-      this.profileForm.value.password as string | null,
-      this.profileForm.value.newPassword as string | null
-    );
-
-    // TODO handle request errors
-
+    this.passwordConfirm = true;
     this.callPasswordWindow(false);
   }
 

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
@@ -78,6 +78,10 @@ export class ProfileSettingsComponent {
     this.passwordError = ""
   }
 
+  /**
+   * Checks to see if there have been any changes to the content of the name, personal email, or phone fields
+   * @returns True if there have been changes, false otherwise
+   */
   checkForChanges(): boolean {
     return this.profileForm.value.name != this.preferredName
           || this.profileForm.value.personal != this.personalEmail

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, ChangeDetectorRef } from '@angular/core';
 import { FormGroup, FormControl } from '@angular/forms';
 import { ReactiveFormsModule, Validators } from '@angular/forms';
 
@@ -37,7 +37,7 @@ export class ProfileSettingsComponent {
     passwordRetype: new FormControl("")
   });
 
-  constructor() {
+  constructor(private cdr: ChangeDetectorRef) {
     // Load necessary settings from database and initialize form
     this.settingsService.getUserInfo(this.loginService.getUserId()).then((userInfo: UserInfo) => {
       this.preferredName = userInfo.name.preferredDisplayName;
@@ -104,6 +104,7 @@ export class ProfileSettingsComponent {
     }
 
     this.passwordConfirm = true;
+    this.cdr.detectChanges();
     this.callPasswordWindow(false);
   }
 

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
@@ -104,15 +104,18 @@ export class ProfileSettingsComponent {
     catch (error: unknown) {
       console.log("DEBUG 3: ERROR UPDATING PASSWORD (ProfileSettingsComponent::attemptPasswordSave)");
       if (error instanceof Error)
-        this.passwordError = error.message;
+        // this.passwordError = error.message;
+        alert(error.message);
       else
-        this.passwordError = "Unexpected error, please try again later";
+        // this.passwordError = "Unexpected error, please try again later";
+        alert("Unexpected error, please try again later");
       return
     }
 
-    this.passwordConfirm = true;
-    this.cdr.detectChanges();
+    // this.passwordConfirm = true;
+    // this.cdr.detectChanges();
     this.callPasswordWindow(false);
+    confirm("Password successfully updated!");
   }
 
   /**

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
@@ -21,7 +21,7 @@ export class ProfileSettingsComponent {
   phoneNumber: string = "";
 
   viewPassword: boolean = false;
-  passwordError: string = "";
+  passwordError: string = " ";
   passwordConfirm: boolean = false;
 
   loginService = inject(LoginService);
@@ -66,9 +66,15 @@ export class ProfileSettingsComponent {
    * @param open True to open the password window, false to close it.
    */
   callPasswordWindow(open: boolean) {
-    console.log("Call popup");
-
     this.viewPassword = open;
+    
+    // Wipe fields and messages
+    this.profileForm.patchValue({
+      password: "",
+      newPassword: "",
+      passwordRetype: ""
+    });
+    this.passwordError = ""
   }
 
   /**

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
@@ -19,6 +19,7 @@ export class ProfileSettingsComponent {
   schoolEmail: string = "";
   personalEmail: string = "";
   phoneNumber: string = "";
+  profileConfirm: boolean = false;
 
   viewPassword: boolean = false;
   passwordError: string = " ";
@@ -77,6 +78,12 @@ export class ProfileSettingsComponent {
     this.passwordError = ""
   }
 
+  checkForChanges(): boolean {
+    return this.profileForm.value.name != this.preferredName
+          || this.profileForm.value.personal != this.personalEmail
+          || this.profileForm.value.phone?.replaceAll("-", "") != this.phoneNumber.replaceAll("-", "");
+  }
+
   /**
    * Attempts to save the user's new password by validating the entry and making the necessary service calls.
    */
@@ -131,5 +138,7 @@ export class ProfileSettingsComponent {
       this.phoneNumber = this.phoneNumber.replaceAll("-", "");  // Remove dashes from user input
       await this.settingsService.updatePhoneNumber(this.loginService.getUserId(), this.phoneNumber);
     }
+
+    this.profileConfirm = true;
   }
 }

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
@@ -20,6 +20,9 @@ export class ProfileSettingsComponent {
   schoolEmail: string = "";
   personalEmail: string = "";
   phoneNumber: string = "";
+  password: string = "";
+
+  viewPassword: boolean = false;
 
   loginService = inject(LoginService);
   settingsService = inject(SettingsService);
@@ -29,7 +32,7 @@ export class ProfileSettingsComponent {
     school: new FormControl({ value: "", disabled: true }, [Validators.required, Validators.email]),
     personal: new FormControl("", [Validators.required, Validators.email]),
     phone: new FormControl("", [Validators.required, Validators.pattern("[0-9]{3}-?[0-9]{3}-?[0-9]{4}")])
-  })
+  });
 
   constructor() {
     // Load necessary settings from database and initialize form
@@ -50,6 +53,25 @@ export class ProfileSettingsComponent {
         phone: this.phoneNumber
       })
     })
+  }
+
+  /**
+   * Opens or closes the password popup based on the given parameter.
+   * @param open True to open the password window, false to close it.
+   */
+  callPasswordWindow(open: boolean) {
+    console.log("Call popup");
+
+    this.viewPassword = open;
+  }
+
+  /**
+   * Attempts to save the user's new password by validating the entry and making the necessary service calls.
+   */
+  attemptPasswordSave() {
+    console.log("Save password");
+
+    this.callPasswordWindow(false);
   }
 
   async saveProfile() {

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
@@ -15,13 +15,13 @@ import { SettingsService } from '../../settings.service';
 })
 export class ProfileSettingsComponent {
   
-  // TODO probably don't need these anymore with reactive forms, but too lazy to get rid of them rn
   preferredName: string = "";
   schoolEmail: string = "";
   personalEmail: string = "";
   phoneNumber: string = "";
-  password: string = "";
 
+  password: string = "";
+  passwordRetype: string = "";
   viewPassword: boolean = false;
 
   loginService = inject(LoginService);
@@ -31,7 +31,9 @@ export class ProfileSettingsComponent {
     name: new FormControl("", Validators.required),
     school: new FormControl({ value: "", disabled: true }, [Validators.required, Validators.email]),
     personal: new FormControl("", [Validators.required, Validators.email]),
-    phone: new FormControl("", [Validators.required, Validators.pattern("[0-9]{3}-?[0-9]{3}-?[0-9]{4}")])
+    phone: new FormControl("", [Validators.required, Validators.pattern("[0-9]{3}-?[0-9]{3}-?[0-9]{4}")]),
+    password: new FormControl(""),
+    passwordRetype: new FormControl("")
   });
 
   constructor() {
@@ -50,7 +52,9 @@ export class ProfileSettingsComponent {
         name: this.preferredName,
         school: this.schoolEmail,
         personal: this.personalEmail,
-        phone: this.phoneNumber
+        phone: this.phoneNumber,
+        password: this.password,
+        passwordRetype: this.passwordRetype
       })
     })
   }
@@ -74,22 +78,25 @@ export class ProfileSettingsComponent {
     this.callPasswordWindow(false);
   }
 
+  /**
+   * Attempts to save profile information, excluding password information
+   */
   async saveProfile() {
 
     // Update preferred name
-    if (this.profileForm.value.name != null) {
+    if (this.profileForm.value.name != null && this.profileForm.value.name != this.preferredName) {
       this.preferredName = this.profileForm.value.name;
       await this.settingsService.updatePreferredName(this.loginService.getUserId(), this.preferredName);
     }
 
     // Update personal email
-    if (this.profileForm.value.personal != null) {
+    if (this.profileForm.value.personal != null && this.profileForm.value.personal != this.personalEmail) {
       this.personalEmail = this.profileForm.value.personal;
       await this.settingsService.updatePersonalEmail(this.loginService.getUserId(), this.personalEmail);
     }
 
     // Update phone number
-    if (this.profileForm.value.phone != null) {
+    if (this.profileForm.value.phone != null && this.profileForm.value.phone != this.phoneNumber) {
       this.phoneNumber = this.profileForm.value.phone;
       this.phoneNumber = this.phoneNumber.replaceAll("-", "");  // Remove dashes from user input
       await this.settingsService.updatePhoneNumber(this.loginService.getUserId(), this.phoneNumber);


### PR DESCRIPTION
Added popup to profile settings that allows the user to change their password by entering their current password, then typing and retyping a new password. Password conditions have been suggested but are a backend change -- the frontend is currently build to handle any backend errors that involve an invalid password change attempt.

The CSS for the popup is pretty much just copied directly from ChatGPT, so people can feel free to edit it as they please. Also not quite sure what to do with the confirmation messages, but they do exist and function properly.

Closes #252