### PR TITLE
Added Notifications to UserInfo

### DIFF
--- a/src/fe-app/src/app/settings.service.spec.ts
+++ b/src/fe-app/src/app/settings.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { SettingsService } from './settings.service';
-import { UserInfo } from './user';
+import { UserInfo, Notifications } from './user';
 
 describe('SettingsService', () => {
   let service: SettingsService;
@@ -47,7 +47,11 @@ describe('SettingsService', () => {
         emailNotifications: true,
         institutionEmailNotifications: true,
         smsNotifications: false
-      }
+      },
+      notifications: [{
+        message: 'test',
+        timestamp: ''
+      }]
     }
 
     const fetchSpy = spyOn(window, 'fetch').and.returnValue(Promise.resolve({

--- a/src/fe-app/src/app/settings/notification-settings/notification-settings.component.spec.ts
+++ b/src/fe-app/src/app/settings/notification-settings/notification-settings.component.spec.ts
@@ -23,18 +23,18 @@ describe('NotificationSettingsComponent', () => {
       institutionEmailNotifications: false,
       smsNotifications: false
     }
-  };
+  } as any;
   const MOCK_PROMISE: Promise<UserInfo> = Promise.resolve(MOCK_USER_INFO);  // Create a promise and resolve it because component constructor uses .then(...)
 
   beforeEach(async () => {
-    
+
     // Note: object notation in createSpyObj() is similar to list but allows mock return values to be defined alongside spy object
     mockLoginService = jasmine.createSpyObj(LoginService, { getUserId: MOCK_USER_INFO.id });
     mockSettingsService = jasmine.createSpyObj(SettingsService, {
       getUserInfo: MOCK_PROMISE,
       updateNotificationSettings: undefined
     });
-    
+
     await TestBed.configureTestingModule({
       imports: [NotificationSettingsComponent],
       providers: [

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.spec.ts
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.spec.ts
@@ -27,12 +27,12 @@ describe('ProfileSettingsComponent', () => {
       institutionEmail: "michael@sc.edu"
     },
     settings: { emailNotifications: false, institutionEmailNotifications: false, smsNotifications: false }
-  };
+  } as any;
   const MOCK_PROMISE: Promise<UserInfo> = Promise.resolve(MOCK_USER_INFO);  // Create a promise and resolve it because component constructor uses .then(...)
   const MOCK_PHONE_AUGMENTED = "012-345-6789"
 
   beforeEach(async () => {
-    
+
     // Note: object notation in createSpyObj() is similar to list but allows mock return values to be defined alongside spy object
     mockLoginService = jasmine.createSpyObj(LoginService, { getUserId: MOCK_USER_INFO.id });
     mockSettingsService = jasmine.createSpyObj(SettingsService, {
@@ -41,7 +41,7 @@ describe('ProfileSettingsComponent', () => {
       updatePersonalEmail: undefined,
       updatePhoneNumber: undefined
     });
-    
+
     await TestBed.configureTestingModule({
       imports: [ProfileSettingsComponent],
       providers: [

--- a/src/fe-app/src/app/user.ts
+++ b/src/fe-app/src/app/user.ts
@@ -10,6 +10,7 @@ export interface UserInfo {
   username: string;
   contact: ContactInfo;
   settings: NotificationSettings;
+  notifications: Notifications[];
 }
 
 export interface ContactInfo {
@@ -28,6 +29,11 @@ export interface Name {
   readonly given: string;
   readonly family: string;
   preferredDisplayName: string;
+}
+
+export interface Notifications {
+  message: string;
+  timestamp: string;
 }
 
 // will need appearance settings for rc1


### PR DESCRIPTION
PR adds notifications to our existing list of UserInfo so it can be easily accessed. 

Additionally, tests were broken during this change. I used `as any` to fix those broken mocks in settings tests as in this case notifications is not a relevant piece to those tests in settings. Adding more mocked data would have been another fix but `as any` is universally accepted when unit testing in angular. I did properly mock in the service testing as it is relevant data