### PR TITLE
Add course filtering to calendar and grades

### DIFF
--- a/src/fe-app/src/app/main/calendar/calendar.component.html
+++ b/src/fe-app/src/app/main/calendar/calendar.component.html
@@ -2,15 +2,17 @@
 <div class="calendar-container">
     @for (dayAssignments of this.weekAssignments; track this.weekAssignments.length) {
         <h1 class="day">{{ this.DAYS_OF_WEEK[$index] }}</h1>
-        @if (countMatchingAssignments(dayAssignments, this.courseService.getSelectIndex()) > 0) {
-            @for (assignment of dayAssignments; track assignment.id) {
-                @if (this.courseService.getSelectIndex() === -1 || assignment.courseId === this.courses[this.courseService.getSelectIndex()].id) {
-                    <p>{{ assignment.title }} | {{ assignment.description }}<p></p>
+        <div class="calendar-element">
+            @if (countMatchingAssignments(dayAssignments, this.courseService.getSelectIndex()) > 0) {
+                @for (assignment of dayAssignments; track assignment.id) {
+                    @if (this.courseService.getSelectIndex() === -1 || assignment.courseId === this.courses[this.courseService.getSelectIndex()].id) {
+                        <p>{{ assignment.title }} | {{ assignment.description }}<p></p>
+                    }
                 }
+            } @else {
+                <p>No assignments this week</p>
             }
-        } @else {
-            <p>No assignments this week</p>
-        }
+        </div>
     }
 
 <!-- TODO Make buttons icons rather than text -->

--- a/src/fe-app/src/app/main/calendar/calendar.component.html
+++ b/src/fe-app/src/app/main/calendar/calendar.component.html
@@ -6,7 +6,7 @@
             @if (countMatchingAssignments(dayAssignments, this.courseService.getSelectIndex()) > 0) {
                 @for (assignment of dayAssignments; track assignment.id) {
                     @if (this.courseService.getSelectIndex() === -1 || assignment.courseId === this.courses[this.courseService.getSelectIndex()].id) {
-                        <p>{{ assignment.title }} | {{ assignment.description }}<p></p>
+                        <p>{{ assignment.title }} | {{ assignment.description }}</p>
                     }
                 }
             } @else {

--- a/src/fe-app/src/app/main/calendar/calendar.component.html
+++ b/src/fe-app/src/app/main/calendar/calendar.component.html
@@ -1,78 +1,15 @@
 <h1>Week of {{ this.formatDate(this.weekStart) }}</h1>
 <div class="calendar-container">
-    <br><div class="day">MONDAY</div>
-    <div class="calendar-element">
-        @if (this.weekAssignments[0].length > 0) {
-            @for (assignment of this.weekAssignments[0]; track assignment.id) {
-                <li>{{ assignment.title }} | {{ assignment.description }}</li>
+    @for (dayAssignments of this.weekAssignments; track this.weekAssignments.length) {
+        <h1 class="day">{{ this.DAYS_OF_WEEK[$index] }}</h1>
+        @if (dayAssignments.length > 0) {
+            @for (assignment of dayAssignments; track assignment.id) {
+                <p>{{ assignment.title }} | {{ assignment.description }}<p>
             }
         } @else {
             <p>No assignments this week</p>
         }
-    </div>
-    <br><div class="day">TUESDAY</div>
-    <div class="calendar-element">
-        @if (this.weekAssignments[1].length > 0) {
-            @for (assignment of this.weekAssignments[1]; track assignment.id) {
-                <li>{{ assignment.title }} | {{ assignment.description }}</li>
-            }
-        } @else {
-            <p>No assignments this week</p>
-        }
-    </div>
-    <br><div class="day">WEDNESDAY</div>
-    <div class="calendar-element">
-        @if (this.weekAssignments[2].length > 0) {
-            @for (assignment of this.weekAssignments[2]; track assignment.id) {
-                <li>{{ assignment.title }} | {{ assignment.description }}</li>
-            }
-        } @else {
-            <p>No assignments this week</p>
-        }
-    </div>
-    <br><div class="day">THURSDAY</div>
-    <div class="calendar-element">
-        @if (this.weekAssignments[3].length > 0) {
-            @for (assignment of this.weekAssignments[3]; track assignment.id) {
-                <li>{{ assignment.title }} | {{ assignment.description }}</li>
-            }
-        } @else {
-            <p>No assignments this week</p>
-        }
-    </div>
-    <br><div class="day">FRIDAY</div>
-    <div class="calendar-element">
-        @if (this.weekAssignments[4].length > 0) {
-            @for (assignment of this.weekAssignments[4]; track assignment.id) {
-                <li>{{ assignment.title }} | {{ assignment.description }}</li>
-            }
-        } @else {
-            <p>No assignments this week</p>
-        }
-    </div>
-    <br><div class="day">SATURDAY</div>
-    <div class="calendar-element">
-        @if (this.weekAssignments[5].length > 0) {
-            @for (assignment of this.weekAssignments[5]; track assignment.id) {
-                <li>{{ assignment.title }} | {{ assignment.description }}</li>
-            }
-        } @else {
-            <p>No assignments this week</p>
-        }
-    </div>
-    <br><div class="day">SUNDAY</div>
-    <div class="calendar-element">
-        @if (this.weekAssignments[6].length > 0) {
-            @for (assignment of this.weekAssignments[6]; track assignment.id) {
-                <li>{{ assignment.title }} | {{ assignment.description }}</li>
-            }
-        } @else {
-            <p>No assignments this week</p>
-        }
-    </div>
-</div>
-
-
+    }
 
 <!-- TODO Make buttons icons rather than text -->
 <div class="page-container">

--- a/src/fe-app/src/app/main/calendar/calendar.component.html
+++ b/src/fe-app/src/app/main/calendar/calendar.component.html
@@ -2,9 +2,9 @@
 <div class="calendar-container">
     @for (dayAssignments of this.weekAssignments; track this.weekAssignments.length) {
         <h1 class="day">{{ this.DAYS_OF_WEEK[$index] }}</h1>
-        @if (dayAssignments.length > 0) {
+        @if (countMatchingAssignments(dayAssignments, this.courseService.getSelectIndex()) > 0) {
             @for (assignment of dayAssignments; track assignment.id) {
-                <p>{{ assignment.title }} | {{ assignment.description }}<p>
+                <p>{{ assignment.title }} | {{ assignment.description }}<p></p>
             }
         } @else {
             <p>No assignments this week</p>

--- a/src/fe-app/src/app/main/calendar/calendar.component.html
+++ b/src/fe-app/src/app/main/calendar/calendar.component.html
@@ -4,7 +4,9 @@
         <h1 class="day">{{ this.DAYS_OF_WEEK[$index] }}</h1>
         @if (countMatchingAssignments(dayAssignments, this.courseService.getSelectIndex()) > 0) {
             @for (assignment of dayAssignments; track assignment.id) {
-                <p>{{ assignment.title }} | {{ assignment.description }}<p></p>
+                @if (this.courseService.getSelectIndex() === -1 || assignment.courseId === this.courses[this.courseService.getSelectIndex()].id) {
+                    <p>{{ assignment.title }} | {{ assignment.description }}<p></p>
+                }
             }
         } @else {
             <p>No assignments this week</p>

--- a/src/fe-app/src/app/main/calendar/calendar.component.ts
+++ b/src/fe-app/src/app/main/calendar/calendar.component.ts
@@ -20,6 +20,7 @@ export class CalendarComponent {
   semesterStart: Date;              // Start of the first week of the current semester
   semesterEnd: Date;                // Start of the week after the end of the current semester
 
+  courses: Course[] = [];
   assignments: Assignment[] = [];
   weekAssignments: Assignment[][] = [[], [], [], [], [], [], []];
 
@@ -31,8 +32,12 @@ export class CalendarComponent {
   // INITIALIZATION
 
   constructor(private assignmentService: AssignmentService) {
+    this.courseService.getCourses(this.loginService.getUserId())
+    .then((courses: Course[]) => {
+      this.courses = courses;
+    })
+    
     const now: Date = new Date(Date.now());
-
     this.weekStart = this.getWeekStart(now);  // Store start of the current week
     this.pageNumber = 0;
 
@@ -105,6 +110,25 @@ export class CalendarComponent {
         break;
       this.weekAssignments[difference / millisecondsPerDay].push(assignment);
     }
+  }
+  
+  /**
+   * Counts the number of assignments in the given assignment list matching the given course index.
+   * @param assignmentList One-dimensional array of assignments, corresponding to a single day.
+   * @param courseIndex Index of the currently-selected course in component course list. -1 indicates no selection
+   * @return The number of assignments that are part of the course corresponding to the given index.
+   */
+  countMatchingAssignments(assignmentList: Assignment[], courseIndex: number): number {
+    if (courseIndex < 0 || courseIndex >= this.courses.length)
+      return assignmentList.length;
+
+    const targetID: string = this.courses[courseIndex].id;
+    let count: number = 0;
+    for (const assignment of assignmentList) {
+      if (assignment.id == targetID)
+        count++;
+    }
+    return count;
   }
 
   /**

--- a/src/fe-app/src/app/main/calendar/calendar.component.ts
+++ b/src/fe-app/src/app/main/calendar/calendar.component.ts
@@ -32,11 +32,6 @@ export class CalendarComponent {
   // INITIALIZATION
 
   constructor(private assignmentService: AssignmentService) {
-    this.courseService.getCourses(this.loginService.getUserId())
-    .then((courses: Course[]) => {
-      this.courses = courses;
-    })
-    
     const now: Date = new Date(Date.now());
     this.weekStart = this.getWeekStart(now);  // Store start of the current week
     this.pageNumber = 0;
@@ -62,6 +57,13 @@ export class CalendarComponent {
       this.loadAssignments().then(() => {
         this.organizeWeekAssignments();
       });
+    })
+  }
+
+  ngOnInit() {
+    this.courseService.getCourses(this.loginService.getUserId())
+    .then((courses: Course[]) => {
+      this.courses = courses;
     })
   }
 
@@ -125,7 +127,7 @@ export class CalendarComponent {
     const targetID: string = this.courses[courseIndex].id;
     let count: number = 0;
     for (const assignment of assignmentList) {
-      if (assignment.id == targetID)
+      if (assignment.courseId === targetID)
         count++;
     }
     return count;

--- a/src/fe-app/src/app/main/calendar/calendar.component.ts
+++ b/src/fe-app/src/app/main/calendar/calendar.component.ts
@@ -26,6 +26,8 @@ export class CalendarComponent {
   loginService = inject(LoginService);
   courseService = inject(CourseService);
 
+  readonly DAYS_OF_WEEK = ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"];
+
   // INITIALIZATION
 
   constructor(private assignmentService: AssignmentService) {

--- a/src/fe-app/src/app/main/grades/grades.component.html
+++ b/src/fe-app/src/app/main/grades/grades.component.html
@@ -9,14 +9,15 @@
 
 <div class="assignment-list">
   <div class="assignment-header">
-      <div class="header-column">COURSE</div>
-      <div class="header-column">ASSIGNMENT</div>
-      <div class="header-column">GRADE</div>
-      <div class="header-column">LETTER</div>
-      <div class="header-column"> </div>
+    <div class="header-column">COURSE</div>
+    <div class="header-column">ASSIGNMENT</div>
+    <div class="header-column">GRADE</div>
+    <div class="header-column">LETTER</div>
+    <div class="header-column"> </div>
   </div>
   <div class="assignment-container">
-      @for (grade of this.grades; track grade.id) {
+    @for (grade of this.grades; track grade.id) {
+      @if (this.courseService.getSelectIndex() === -1 || grade.courseId === this.courses[this.courseService.getSelectIndex()].id) {
         <div class="assignment-row">
         <div class="assignment-column">{{ this.getCourseNameByID(grade.courseId) }}</div>
         <div class="assignment-column">{{ this.getAssignmentTitleByID(grade.assignmentId) }}</div>
@@ -27,6 +28,7 @@
           </div>
           </div>
       }
+    }
   </div>
 </div>
 

--- a/src/fe-app/src/app/main/task-list/task-list.component.html
+++ b/src/fe-app/src/app/main/task-list/task-list.component.html
@@ -10,7 +10,7 @@
     </div>
     <div class="assignment-container">
         @for (assignment of this.assignments[this.getIndex()]; track assignment.id) {
-            @if (courseService.getSelectIndex() === -1 || assignment.courseId === courses[courseService.getSelectIndex()].id) {
+            @if (this.courseService.getSelectIndex() === -1 || assignment.courseId === this.courses[this.courseService.getSelectIndex()].id) {
                 <app-task
                 [assignment]="assignment"
                 [courseName]="this.getCourseNameByID(assignment.courseId)"


### PR DESCRIPTION
Also includes a calendar component template refactor, turning the static 7 sections into a single @for loop with header content moved to a readonly array within the class file.

Closes #360