### PR TITLE
Move Asynchronous Logic Out of Constructors

### DIFF
--- a/src/fe-app/src/app/assignment.service.ts
+++ b/src/fe-app/src/app/assignment.service.ts
@@ -18,8 +18,10 @@ export class AssignmentService {
   private signalValue: number = 0;
   private updateSignal: WritableSignal<number> = signal<number>(this.signalValue);
 
-  constructor() {
-    if(this.loginService.getUserId()) {
+  constructor() {}
+
+  ngOnInit() {
+    if (this.loginService.getUserId()) {
       this.fetchAssignments(this.loginService.getUserId())
       .then((assignments: Assignment[]) => {
         this.assignments = assignments;

--- a/src/fe-app/src/app/course.service.ts
+++ b/src/fe-app/src/app/course.service.ts
@@ -13,7 +13,6 @@ export class CourseService {
   constructor() {
     const storedIndex = localStorage.getItem(this.STORAGE_KEY);
     this.selectIndex = storedIndex !== null ? parseInt(storedIndex, 10) : -1;
-    //this.selectIndex = -1;
   }
 
   async getCourses(userId: string | null) : Promise<Course[]> {

--- a/src/fe-app/src/app/home/home.component.ts
+++ b/src/fe-app/src/app/home/home.component.ts
@@ -16,13 +16,6 @@ export class HomeComponent {
   currentValue: string = ''; // is this needed?
   loginService = inject(LoginService);
 
-  ngOnInit(): void {
-    //const userId = this.loginService.getUserId();
-    //if(userId) {
-      //this.router.navigateByUrl('/main/task-list');
-    //}
-  }
-
   constructor(public activatedRoute: ActivatedRoute) {}
 
   // we can go back to routerLink in the html, but I am yet to find a good way to test it

--- a/src/fe-app/src/app/login/login.component.ts
+++ b/src/fe-app/src/app/login/login.component.ts
@@ -13,13 +13,6 @@ import { User } from '../user';
   styleUrl: './login.component.css'
 })
 export class LoginComponent implements OnInit {
-  ngOnInit(): void {
-    const userId = this.loginService.getUserId();
-    if(userId) {
-      this.router.navigateByUrl('/main/task-list');
-    }
-  }
-
   router = inject(Router);
   user: User | undefined;
   loginService = inject(LoginService);
@@ -28,7 +21,13 @@ export class LoginComponent implements OnInit {
     password: new FormControl('', Validators.required)
   });
 
-  // username: osterholt; password: cameron1234
+  ngOnInit(): void {
+    const userId = this.loginService.getUserId();
+    if(userId) {
+      this.router.navigateByUrl('/main/task-list');
+    }
+  }
+
   login() {
     if (this.loginForm.invalid) {
       alert('A field is blank');

--- a/src/fe-app/src/app/main/add-task/add-task.component.ts
+++ b/src/fe-app/src/app/main/add-task/add-task.component.ts
@@ -38,21 +38,14 @@ export class AddTaskComponent {
     due: new FormControl('', Validators.required)
   });
 
-  // name: string = "";
-  // description: string = "";
-  // course: string = "";
-  // // course: undefined; // TODO update type to Course when interface is created
-  // due: Date = new Date();
+  constructor() {}
 
-  // displayOutput: boolean = false;  // TODO for testing, remove later
-
-  constructor() {
+  ngOnInit() {
     this.courseService.getCourses(this.loginService.getUserId())
     .then((courses: Course[]) => {
       this.courses = courses;
     })
   }
-
 
   async addTask() {
     console.log("AddTaskComponent - ADD TASK");

--- a/src/fe-app/src/app/main/courses-sidebar/courses-sidebar.component.ts
+++ b/src/fe-app/src/app/main/courses-sidebar/courses-sidebar.component.ts
@@ -13,15 +13,14 @@ import { LoginService } from '../../login.service';
 export class CoursesSidebarComponent {
   courses: Course[] = [];
 
-  constructor(
-    protected courseService: CourseService,  
-    private loginService: LoginService  
-  ) {
+  constructor(protected courseService: CourseService, private loginService: LoginService) {}
+
+  ngOnInit() {
     // Retrieve course list from CourseService and store it in courses
     this.courseService.getCourses(this.loginService.getUserId())
-      .then((courses: Course[]) => {
-        this.courses = courses;
-      });
+    .then((courses: Course[]) => {
+      this.courses = courses;
+    });
 
     // Ensure no course is selected on page load
     //this.courseService.deselectCourse();

--- a/src/fe-app/src/app/main/edit-task/edit-task.component.ts
+++ b/src/fe-app/src/app/main/edit-task/edit-task.component.ts
@@ -32,7 +32,13 @@ export class EditTaskComponent implements OnInit {
     due: new FormControl('', Validators.required)
   });
 
-  async ngOnInit() {
+  constructor() {}
+
+  ngOnInit() {
+    this.courseService.getCourses(this.loginService.getUserId())
+    .then((courses: Course[]) => {
+      this.courses = courses;
+    })
 
     try {
       if (this.assignment) {
@@ -55,18 +61,11 @@ export class EditTaskComponent implements OnInit {
           console.log(value);
         })
       }
-    } catch (error) {
+    }
+    catch (error) {
       console.error('Error fetching assignments:', error);
     }
   }
-
-  constructor() {
-    this.courseService.getCourses(this.loginService.getUserId())
-    .then((courses: Course[]) => {
-      this.courses = courses;
-    })
-  }
-
 
   async editTask() {
     if(this.editTaskForm.invalid) {

--- a/src/fe-app/src/app/main/grades/grades.component.ts
+++ b/src/fe-app/src/app/main/grades/grades.component.ts
@@ -28,7 +28,9 @@ export class GradesComponent {
   showPopup = false;
   popupType: 'calculator' | null = null;
 
-  constructor() {
+  constructor() {}
+
+  ngOnInit() {
     this.courseService.getCourses(this.loginService.getUserId())
     .then((courses: Course[]) => {
       this.courses = courses;

--- a/src/fe-app/src/app/main/main.component.ts
+++ b/src/fe-app/src/app/main/main.component.ts
@@ -54,11 +54,6 @@ export class MainComponent implements OnInit {
         }
     }
 
-    // handleDueSoonAssignments(assignments: Assignment[]): void {
-    //     console.log('Top 3 Due Soon Assignments:', assignments);
-    //     this.topThreeAssignments = assignments;
-    // }
-
     getUserId(): void {
         console.log(this.loginService.getUserId());
         if (this.loginService.getUserId()) {

--- a/src/fe-app/src/app/main/secondary-sidebar/secondary-sidebar.component.ts
+++ b/src/fe-app/src/app/main/secondary-sidebar/secondary-sidebar.component.ts
@@ -29,10 +29,6 @@ export class SecondarySidebarComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges) {}
 
   constructor(private assignmentService: AssignmentService) {
-    this.courseService.getCourses(this.loginService.getUserId())
-    .then((courses: Course[]) => {
-      this.courses = courses;
-    })
 
     // Set logic to run whenever the AssignmentService signal updates (e.g. its constructor finishes or an assignment is added)
     effect(() => {
@@ -42,6 +38,13 @@ export class SecondarySidebarComponent implements OnChanges {
       this.assignmentService.getAssignments(this.loginService.getUserId()).then((assignments: Assignment[]) => {
         this.filterTopThree(assignments)
       });
+    })
+  }
+
+  ngOnInit() {
+    this.courseService.getCourses(this.loginService.getUserId())
+    .then((courses: Course[]) => {
+      this.courses = courses;
     })
 
     this.gradesService.getGrades(this.loginService.getUserId())

--- a/src/fe-app/src/app/main/task-list/task-list.component.ts
+++ b/src/fe-app/src/app/main/task-list/task-list.component.ts
@@ -32,18 +32,20 @@ export class TaskListComponent{
   sortedAssignments: Assignment[] = [];
 
   constructor(private assignmentService: AssignmentService, private cdr: ChangeDetectorRef) {
-    // Populate course list with service call
-    this.courseService.getCourses(this.loginService.getUserId())
-    .then((courses: Course[]) => {
-      this.courses = courses;
-    });
-
     // Set logic to run whenever the AssignmentService signal updates (e.g. its constructor finishes or an assignment is added)
     effect(() => {
       const signal = this.assignmentService.getUpdateSignal();  // Referencing the signal is necessary for it to work
       console.log("SIGNAL RUN: Value " + signal);
       this.loadAssignments();                                   // Runs when service constructor finishes, no need to call twice
     })
+  }
+
+  ngOnInit() {
+    // Populate course list with service call
+    this.courseService.getCourses(this.loginService.getUserId())
+    .then((courses: Course[]) => {
+      this.courses = courses;
+    });
   }
 
   private async loadAssignments() {

--- a/src/fe-app/src/app/main/task-list/task/task.component.ts
+++ b/src/fe-app/src/app/main/task-list/task/task.component.ts
@@ -32,13 +32,7 @@ export class TaskComponent implements OnInit {
 
   constructor(private assignmentService: AssignmentService) {}
 
-  async ngOnInit() {
-    //try {
-    //  this.courseName = await (await this.courseService.getCourseById(this.assignment.courseId)).name;
-    //} catch (error) {
-    //  console.error('Error fetching course:', error);
-    //}
-  }
+  ngOnInit() {}
 
   async toggleCompletion(assignment: Assignment) {
     // console.log("clicked");

--- a/src/fe-app/src/app/notifications/notifications.component.ts
+++ b/src/fe-app/src/app/notifications/notifications.component.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
-import { RouterOutlet, RouterModule } from '@angular/router';
+import { RouterModule } from '@angular/router';
 
 
 @Component({
   selector: 'app-notifications',
   standalone: true,
-  imports: [RouterOutlet, RouterModule],
+  imports: [RouterModule],
   templateUrl: './notifications.component.html',
   styleUrl: './notifications.component.css'
 })

--- a/src/fe-app/src/app/settings/notification-settings/notification-settings.component.ts
+++ b/src/fe-app/src/app/settings/notification-settings/notification-settings.component.ts
@@ -20,7 +20,9 @@ export class NotificationSettingsComponent {
   loginService = inject(LoginService);
   settingsService = inject(SettingsService);
 
-  constructor() {
+  constructor() {}
+
+  ngOnInit() {
     this.settingsService.getUserInfo(this.loginService.getUserId()).then((userInfo: UserInfo) => {
       let userSettings: NotificationSettings = userInfo.settings;
       this.useSchoolEmail = userSettings.institutionEmailNotifications;

--- a/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
+++ b/src/fe-app/src/app/settings/profile-settings/profile-settings.component.ts
@@ -38,7 +38,9 @@ export class ProfileSettingsComponent {
     passwordRetype: new FormControl("")
   });
 
-  constructor(private cdr: ChangeDetectorRef) {
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  ngOnInit() {
     // Load necessary settings from database and initialize form
     this.settingsService.getUserInfo(this.loginService.getUserId()).then((userInfo: UserInfo) => {
       this.preferredName = userInfo.name.preferredDisplayName;

--- a/src/fe-app/src/app/settings/settings.component.ts
+++ b/src/fe-app/src/app/settings/settings.component.ts
@@ -13,11 +13,11 @@ import { LoginService } from '../login.service';
   styleUrl: './settings.component.css'
 })
 export class SettingsComponent {
-  constructor() {}
-
   userInfo: UserInfo | undefined;
   settingsService = inject(SettingsService);
   loginService = inject(LoginService);
+
+  constructor() {}
 
   getInfo() {
     this.settingsService.getUserInfo(this.loginService.getUserId()).then((userInfo: UserInfo) => {


### PR DESCRIPTION
Moves asynchronous logic from component/service constructors into ngOnInit functions where applicable as per requirements stated in #411. Also gets rid of some commented code and re-orders some class code for consistency.

I would HIGHLY recommend stress testing this -- refresh, hit buttons, mess around with it as much as you can to make sure nothing ends up hanging as a result of the app not stabilizing. I would also encourage you to check through the changed files to make sure that I didn't miss any async logic (with the exception of signal/effect definitions, as per issue #411).

After these changes, it does seem like the frequency/severity of slow image loads on the main and settings page has severely dropped, so it looks like async logic was interfering with stabilization after all.