### PR TITLE
Move Assignment Immediately on Complete/Un-complete

### DIFF
--- a/src/fe-app/src/app/assignment.service.ts
+++ b/src/fe-app/src/app/assignment.service.ts
@@ -182,9 +182,9 @@ export class AssignmentService {
       if(!response.ok) {
         throw new Error(`PUT failed: ${response.status}`)
       }
-
-      console.log(response);
-    } catch (error: unknown) {
+      this.updateSignal.set(++this.signalValue);
+    }
+    catch (error: unknown) {
       if (error instanceof Error) {
         console.error('Error completing task:', error.message);
       } else {
@@ -208,9 +208,9 @@ export class AssignmentService {
       if(!response.ok) {
         throw new Error(`PUT failed: ${response.status}`)
       }
-
-      console.log(response);
-    } catch (error: unknown) {
+      this.updateSignal.set(++this.signalValue);
+    }
+    catch (error: unknown) {
       if (error instanceof Error) {
         console.error('Error opening task:', error.message);
       } else {

--- a/src/fe-app/src/app/assignment.service.ts
+++ b/src/fe-app/src/app/assignment.service.ts
@@ -184,15 +184,9 @@ export class AssignmentService {
 
       // Update assignment in stored array and update signal for components
       for (let assignment of this.assignments) {
-        if (assignment.id === assignmentId && assignment.complete === false) {
+        if (assignment.id === assignmentId && assignment.complete === false)
           assignment.complete = true;
-          this.updateSignal.set(++this.signalValue);
-          return;
-        }
       }
-
-      // If assignment exists but is not in stored array for whatever reason, fetch
-      this.assignments = await this.fetchAssignments(this.loginService.getUserId());
       this.updateSignal.set(++this.signalValue);
     }
     catch (error: unknown) {
@@ -221,15 +215,9 @@ export class AssignmentService {
       
       // Update assignment in stored array and update signal for components
       for (let assignment of this.assignments) {
-        if (assignment.id === assignmentId && assignment.complete === true) {
+        if (assignment.id === assignmentId && assignment.complete === true)
           assignment.complete = true;
-          this.updateSignal.set(++this.signalValue);
-          return;
-        }
       }
-
-      // If assignment exists but is not in stored array for whatever reason, fetch
-      this.assignments = await this.fetchAssignments(this.loginService.getUserId());
       this.updateSignal.set(++this.signalValue);
     }
     catch (error: unknown) {

--- a/src/fe-app/src/app/main/task-list/task-list.component.html
+++ b/src/fe-app/src/app/main/task-list/task-list.component.html
@@ -1,6 +1,6 @@
 <div class="assignment-list">
   <div class="assignment-header">
-      <div class="header-column" ><button class="checkmark-button" style = "color:red; border-color: red;" (click)="test()">✔</button></div>
+      <div class="header-column" ><button class="checkmark-button" style = "color:red; border-color: red;" (click)="toggleView()">✔</button></div>
       <div class="header-column">COURSE</div>
       <div class="header-column">TITLE</div>
       <div class="header-column">DUE</div>

--- a/src/fe-app/src/app/main/task-list/task-list.component.ts
+++ b/src/fe-app/src/app/main/task-list/task-list.component.ts
@@ -109,7 +109,7 @@ export class TaskListComponent{
     this.cdr.detectChanges();
   }
 
-  test(): void {
+  toggleView(): void {
     this.assignmentService.toggleViewCompleted();
   }
 

--- a/src/fe-app/src/app/main/task-list/task-list.component.ts
+++ b/src/fe-app/src/app/main/task-list/task-list.component.ts
@@ -59,7 +59,7 @@ export class TaskListComponent{
   filterAssignments(assignments: Assignment[]) {
     let newAssignments: Assignment[][] = [ [], [] ];
     for (const assignment of assignments) {
-      if (assignment.complete && Date.now() >= (new Date(assignment.availability.adaptiveRelease.end)).getTime())
+      if (assignment.complete)
         newAssignments[COMPLETE].push(assignment);
       else
         newAssignments[ACTIVE].push(assignment);


### PR DESCRIPTION
Toggling the checkbox associated with a task now moves it to the corresponding page as soon as the REST API call gives a successful response. Currently working out a bug where the first toggle after a refresh undoes the checkbox toggle and does not move the assignment in question despite what looks like an OK response from the API. Refreshing the page after this behavior shows the assignment on the correct page, indicating the request was processed successfully.

Closes #358 when merged