### PR TITLE
Fix Final Grade Not Updating on Grade Change

### DIFF
--- a/src/fe-app/src/app/grades.service.ts
+++ b/src/fe-app/src/app/grades.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, WritableSignal, signal } from '@angular/core';
 import { Grade } from './course';
 
 @Injectable({
@@ -7,7 +7,14 @@ import { Grade } from './course';
 export class GradesService {
   readonly url = 'https://classmate.osterholt.us/api/';
 
+  private signalValue: boolean = false;
+  private updateSignal: WritableSignal<boolean> = signal<boolean>(this.signalValue);
+
   constructor() { }
+
+  getUpdateSignal() {
+    return this.updateSignal();
+  }
 
   /**
    * API call to get all grades for a user
@@ -39,30 +46,32 @@ export class GradesService {
    * @param percent
    */
   async setGrade(gradeId: string | null, percent: number | null) : Promise<void> {
-      const queryParams = new URLSearchParams({
-        gradeId: gradeId ?? "NULL",
-        percent: percent?.toString() ?? "NULL"
-      }).toString();
+    const queryParams = new URLSearchParams({
+      gradeId: gradeId ?? "NULL",
+      percent: percent?.toString() ?? "NULL"
+    }).toString();
 
-      console.log(queryParams);
+    console.log(queryParams);
 
-      try {
-        const response = await fetch(`${this.url}setGrade?${queryParams}`, {
-          method: 'POST'
-        });
+    try {
+      const response = await fetch(`${this.url}setGrade?${queryParams}`, {
+        method: 'POST'
+      });
 
-        if(!response.ok) {
-          throw new Error(`POST failed: ${response.status}`)
-        }
-
-        console.log(response);
-      } catch (error: unknown) {
-        if (error instanceof Error) {
-          console.error('Error setting grade:', error.message);
-        } else {
-          console.error('Unexpected error', error);
-        }
-        throw error;
+      if(!response.ok) {
+        throw new Error(`POST failed: ${response.status}`)
       }
+
+      this.signalValue = !this.signalValue;
+      this.updateSignal.set(this.signalValue);
+
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error('Error setting grade:', error.message);
+      } else {
+        console.error('Unexpected error', error);
+      }
+      throw error;
+    }
   }
 }

--- a/src/fe-app/src/app/main/secondary-sidebar/secondary-sidebar.component.ts
+++ b/src/fe-app/src/app/main/secondary-sidebar/secondary-sidebar.component.ts
@@ -32,7 +32,7 @@ export class SecondarySidebarComponent implements OnChanges {
     // Set logic to run whenever the AssignmentService signal updates (e.g. its constructor finishes or an assignment is added)
     effect(() => {
       const signal = this.assignmentService.getUpdateSignal();  // Referencing the signal is necessary for it to work
-      console.log("SIDEBAR SIGNAL RUN: Value " + signal);
+      console.log("SIDEBAR SIGNAL DUE SOON RUN: Value " + signal);
 
       // Runs when service constructor finishes, no need to call twice
       this.assignmentService.getAssignments(this.loginService.getUserId()).then((assignments: Assignment[]) => {
@@ -41,6 +41,17 @@ export class SecondarySidebarComponent implements OnChanges {
         this.cdr.detectChanges();
       });
     });
+
+    // Set logic to run whenever the GradesService signal updates (for when a grade is updated)
+    effect(() => {
+      const signal = this.gradesService.getUpdateSignal();
+      console.log("SIDEBAR SIGNAL GRADES RUN: Value " + signal);
+
+      this.gradesService.getGrades(this.loginService.getUserId())
+      .then((grades: Grade[]) => {
+        this.grades = grades;
+      })
+    })
   }
 
   ngOnInit() {


### PR DESCRIPTION
Adds a signal to the grade service that prompts the secondary sidebar to re-fetch grades when an assignment's grade is updated. Does not include major refactors like the AssignmentService change did because grades are used in much simpler contexts.