### PR TITLE
Remove alert() and confirm()

### DIFF
--- a/src/fe-app/src/app/login/login.component.css
+++ b/src/fe-app/src/app/login/login.component.css
@@ -14,14 +14,14 @@ main{
 .username label,
 .password label {
   display: block;
-  margin-bottom: 5px; 
-  
+  margin-bottom: 5px;
+
 }
 
 .forms .username,
 .forms .password,
 .forms .submit {
-  margin: 40px 0; 
+  margin: 40px 0;
 }
 
 h1{
@@ -34,4 +34,9 @@ h1{
   justify-self: center;
   padding-top: 10px;
 }
-  
+
+.error {
+  color: red;
+  margin-top: 10px;
+  font-size: 15px;
+}

--- a/src/fe-app/src/app/login/login.component.html
+++ b/src/fe-app/src/app/login/login.component.html
@@ -15,5 +15,6 @@
         <button type="submit" style = "border-radius: 10px;">Login</button>
       </div>
     </form>
+    <span class="error">{{ errorMessage }}</span>
   </div>
 </main>

--- a/src/fe-app/src/app/login/login.component.spec.ts
+++ b/src/fe-app/src/app/login/login.component.spec.ts
@@ -74,8 +74,7 @@ describe('LoginComponent', () => {
     expect(mockRouter.navigateByUrl).toHaveBeenCalledWith('/main/task-list'); // expect the mock router to have routed to /main
   });
 
-  it('should show an alert message when login fails', async () => { // async due to changes occurring on actual page (maybe?)
-    spyOn(window, 'alert');
+  it('should not login a user when login fails', async () => { // async due to changes occurring on actual page (maybe?)
     component.loginForm.setValue({ username: 'testuser', password: 'wrongpassword'}); // pass in fake invalid info
     mockLoginService.login.and.returnValue(Promise.reject('Invalid credentials')); // call the mock service and give a rejected return (why)
 
@@ -83,12 +82,10 @@ describe('LoginComponent', () => {
 
     await fixture.isStable()
     fixture.detectChanges(); // detect the changes on the page
-    expect(window.alert).toHaveBeenCalledWith('Invalid login credentials');
     expect(mockRouter.navigateByUrl).not.toHaveBeenCalled(); // expect mock router to have not been called
   });
 
   it('should not call loginService.login if the form is empty ', async () => { // also async due to page tracking (maybe?)
-    spyOn(window, 'alert');
     component.loginForm.setValue({ username: '', password: ''}); // pass in no info
 
     await component.login(); // call login with no info (await bc function is async)
@@ -96,6 +93,5 @@ describe('LoginComponent', () => {
     await fixture.isStable();
     fixture.detectChanges(); // detect the changes on the page
     expect(mockLoginService.login).not.toHaveBeenCalled(); // expect the login service to not get called
-    expect(window.alert).toHaveBeenCalledWith('A field is blank');
   });
 });

--- a/src/fe-app/src/app/login/login.component.ts
+++ b/src/fe-app/src/app/login/login.component.ts
@@ -19,6 +19,7 @@ export class LoginComponent implements OnInit {
     username: new FormControl('', Validators.required),
     password: new FormControl('', Validators.required)
   });
+  errorMessage: string | null = null;
 
   ngOnInit(): void {
     const userId = this.loginService.getUserId();
@@ -29,7 +30,7 @@ export class LoginComponent implements OnInit {
 
   login() {
     if (this.loginForm.invalid) {
-      alert('A field is blank');
+      this.errorMessage = 'A field is blank';
      return;
     }
 
@@ -44,7 +45,7 @@ export class LoginComponent implements OnInit {
       }
     })
     .catch((error) => {
-      alert('Invalid login credentials');
+      this.errorMessage = 'Invalid login credentials';
       console.error('Login failed', error);
     });
   };

--- a/src/fe-app/src/app/main/add-task/add-task.component.css
+++ b/src/fe-app/src/app/main/add-task/add-task.component.css
@@ -52,3 +52,15 @@ a {
   margin-top: 8px;
   font-size: 14px;
 }
+
+.error {
+  color: red;
+  margin-top: 10px;
+  font-size: 15px;
+}
+
+.success {
+  color: #454545;
+  margin-top: 10px;
+  font-size: 15px;
+}

--- a/src/fe-app/src/app/main/add-task/add-task.component.css
+++ b/src/fe-app/src/app/main/add-task/add-task.component.css
@@ -41,6 +41,10 @@ a {
   margin-left: 12px;
 }
 
+#description {
+  max-width: 100%;
+}
+
 .button-container {
   display: flex;
   flex-direction: column;

--- a/src/fe-app/src/app/main/add-task/add-task.component.html
+++ b/src/fe-app/src/app/main/add-task/add-task.component.html
@@ -24,6 +24,8 @@
         <a (click)="addMoreTasks()" style = "margin-top: 24px; font-size: 18px;">Add Another</a>
       </div>
     </form>
+    <span class="error">{{ errorMessage }}</span>
+    <span class="success">{{ successMessage }}</span>
   </div>
 </div>
 

--- a/src/fe-app/src/app/main/edit-task/edit-task.component.css
+++ b/src/fe-app/src/app/main/edit-task/edit-task.component.css
@@ -24,3 +24,9 @@ button[type="submit"] {
   margin-top: 20px;
   font-size: 18px;
 }
+
+.error {
+  color: red;
+  margin-top: 10px;
+  font-size: 15px;
+}

--- a/src/fe-app/src/app/main/edit-task/edit-task.component.css
+++ b/src/fe-app/src/app/main/edit-task/edit-task.component.css
@@ -14,13 +14,14 @@ input, select {
   margin-left: 10px;
 }
 
+#description {
+  max-width: 100%;
+}
+
 button[type="submit"] {
-  display: block;
   margin: 20px auto 0;
   margin-top: 10px;
-  margin-left: 10px;
   border-radius: 10px;
-  justify-self: center;
   margin-top: 20px;
   font-size: 18px;
 }
@@ -29,4 +30,11 @@ button[type="submit"] {
   color: red;
   margin-top: 10px;
   font-size: 15px;
+}
+
+.form-button {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }

--- a/src/fe-app/src/app/main/edit-task/edit-task.component.html
+++ b/src/fe-app/src/app/main/edit-task/edit-task.component.html
@@ -19,6 +19,8 @@
     </option>
   </select>
 
-  <button type="submit">Save</button>
+  <div class="form-button">
+    <button type="submit">Save</button>
+  </div>
 </form>
 <span class="error">{{ errorMessage }}</span>

--- a/src/fe-app/src/app/main/edit-task/edit-task.component.html
+++ b/src/fe-app/src/app/main/edit-task/edit-task.component.html
@@ -21,3 +21,4 @@
 
   <button type="submit">Save</button>
 </form>
+<span class="error">{{ errorMessage }}</span>

--- a/src/fe-app/src/app/main/edit-task/edit-task.component.ts
+++ b/src/fe-app/src/app/main/edit-task/edit-task.component.ts
@@ -122,8 +122,8 @@ export class EditTaskComponent implements OnInit {
 
       this.close.emit(updatedAssignment);
     } catch(error) {
-      console.error('Add task failed', error);
-      this.errorMessage = 'An error occurred while adding the task. Please try again.';
+      console.error('Edit task failed', error);
+      this.errorMessage = 'An error occurred while editing the task. Please try again.';
 
       if(error instanceof Error) {
         if(error.message.includes('400')) {

--- a/src/fe-app/src/app/main/edit-task/edit-task.component.ts
+++ b/src/fe-app/src/app/main/edit-task/edit-task.component.ts
@@ -23,6 +23,7 @@ export class EditTaskComponent implements OnInit {
   courseService = inject(CourseService);
   assignmentService = inject(AssignmentService);
   courses: Course[] = [];
+  errorMessage: string | null = null;
 
   editTaskForm = new FormGroup ({
     title: new FormControl('', Validators.required),
@@ -121,7 +122,14 @@ export class EditTaskComponent implements OnInit {
 
       this.close.emit(updatedAssignment);
     } catch(error) {
-      console.error('Edit task failed', error);
+      console.error('Add task failed', error);
+      this.errorMessage = 'An error occurred while adding the task. Please try again.';
+
+      if(error instanceof Error) {
+        if(error.message.includes('400')) {
+          this.errorMessage = 'Duplicate task. Please try again.';
+        }
+      }
     }
   }
 }

--- a/src/fe-app/src/app/main/task-list/task-list.component.spec.ts
+++ b/src/fe-app/src/app/main/task-list/task-list.component.spec.ts
@@ -92,7 +92,6 @@ describe('TaskListComponent', () => {
     const taskToRemove = { id: '1' } as Assignment;
     component.assignments[0] = [taskToRemove];
 
-    spyOn(window, 'confirm').and.returnValue(true);
     component.onTaskRemoved(taskToRemove.id as string);
 
     expect(component.assignments[0].length).toBe(0);

--- a/src/fe-app/src/app/main/task-list/task-list.component.ts
+++ b/src/fe-app/src/app/main/task-list/task-list.component.ts
@@ -115,17 +115,14 @@ export class TaskListComponent{
    * @param id
    */
   onTaskRemoved(id: string) {
-    if(confirm('Are you sure?')) {
-      this.assignments = this.assignments.map(list =>
-        list.filter(assignment => assignment.id !== id)
-      )
+    this.assignments = this.assignments.map(list =>
+      list.filter(assignment => assignment.id !== id)
+    )
 
-      this.sortedAssignments = this.getSortedAssignments();
-      this.cdr.detectChanges();
-      } else {
-        return;
-      }
+    this.sortedAssignments = this.getSortedAssignments();
+    this.cdr.detectChanges();
   }
+
 
   /**
    * updateTask function that updates a task in the list of assignments

--- a/src/fe-app/src/app/main/task-list/task/task.component.css
+++ b/src/fe-app/src/app/main/task-list/task/task.component.css
@@ -36,9 +36,9 @@
     line-height: 1.7;
 }
 
-  .description, .course{
-    font-weight: bold;
-  }
+.description, .course{
+  font-weight: bold;
+}
 
 .assignment-column:last-child {
     border-right: none;
@@ -89,4 +89,38 @@
     cursor: pointer;
     font-size: 34px;
     color: black;
+  }
+
+  .popup-content .close {
+    position: absolute;
+    top: 12px;
+    right: 16px;
+    font-size: 24px;
+    cursor: pointer;
+    color: #555;
+  }
+
+  .confirm-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    margin-top: 20px;
+  }
+
+  .confirm-buttons button {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+  }
+
+  .confirm-buttons .yes-button {
+    background-color: #c30000;
+    color: white;
+  }
+
+  .confirm-buttons .no-button {
+    background-color: #949494;
+    color: white;
   }

--- a/src/fe-app/src/app/main/task-list/task/task.component.html
+++ b/src/fe-app/src/app/main/task-list/task/task.component.html
@@ -3,7 +3,7 @@
         <input type="checkbox" [(ngModel)]="assignment.complete" (click)="toggleCompletion(assignment)" />
     </div>
     <div class="assignment-column">{{ courseName.split("-")[0] }}</div>
-    <div class="assignment-column" style = "text-decoration: underline; font-weight: 500; cursor: pointer; opacity: 1; transition: opacity 0.3s;" onmouseover="this.style.opacity='0.6'" 
+    <div class="assignment-column" style = "text-decoration: underline; font-weight: 500; cursor: pointer; opacity: 1; transition: opacity 0.3s;" onmouseover="this.style.opacity='0.6'"
     onmouseout="this.style.opacity='1'"><a (click)="openPopup('task')" >{{ assignment.title }}</a></div>
     <div class="assignment-column" style = "color: #c30000">{{ assignment.availability.adaptiveRelease.end | date }}</div>
     <div class="assignment-column">
@@ -11,7 +11,7 @@
         <a (click)="openPopup('edit-task')" style="cursor: pointer;">
           <img *ngIf="assignment.userCreated" src="images/pencil.png" alt="pencil icon" style="width: 25px; height: auto;"/>
         </a>
-        <a (click)="removeTask()" style="cursor: pointer;">
+        <a (click)="confirmDeleteTask()" style="cursor: pointer;">
           <img *ngIf="assignment.userCreated" src="images/x.png" alt="x icon" style="width: 20px; height: auto;"/>
         </a>
       </div>
@@ -34,3 +34,13 @@
     </div>
   </div>
 
+  <div *ngIf="showConfirmDelete" class="popup-modal" (click)="cancelDelete()">
+    <div class="popup-content" style="max-width: 500px;" (click)="$event.stopPropagation()">
+      <span class="close" (click)="cancelDelete()">&times;</span>
+      <p>Are you sure you want to delete this task?</p>
+      <div class="confirm-buttons">
+        <button class="yes-button" (click)="removeTask()">Yes</button>
+        <button class="no-button" (click)="cancelDelete()">No</button>
+      </div>
+    </div>
+  </div>

--- a/src/fe-app/src/app/main/task-list/task/task.component.spec.ts
+++ b/src/fe-app/src/app/main/task-list/task/task.component.spec.ts
@@ -70,6 +70,33 @@ describe('TaskComponent', () => {
     expect(mockAssignmentService.completeTask).toHaveBeenCalledWith(assignmentId);
   });
 
+  it('should confirm delete task', () => {
+    component.confirmDeleteTask();
+    expect(component.showConfirmDelete).toBeTrue();
+  });
+
+  it('should cancel delete task', () => {
+    component.cancelDelete();
+    expect(component.showConfirmDelete).toBeFalse();
+  });
+
+  it('should call removeTask() if yes-button is clicked on the modal', () => {
+    spyOn(component, 'removeTask').and.callThrough();
+    component.confirmDeleteTask();
+    component.removeTask();
+
+    expect(component.removeTask).toHaveBeenCalled();
+  }
+  );
+
+  it('should call cancelDelete() if no-button is clicked on the modal', () => {
+    spyOn(component, 'cancelDelete').and.callThrough();
+    component.confirmDeleteTask();
+    component.cancelDelete();
+
+    expect(component.cancelDelete).toHaveBeenCalled();
+  });
+
   it('should remove task', () => {
     const assignmentId = '12345';
     component.assignment.id = assignmentId;

--- a/src/fe-app/src/app/main/task-list/task/task.component.ts
+++ b/src/fe-app/src/app/main/task-list/task/task.component.ts
@@ -26,6 +26,7 @@ export class TaskComponent implements OnInit {
   loginService = inject(LoginService)
   showPopup = false;
   popupType: 'edit-task' | 'task' | null = null;
+  showConfirmDelete = false;
   //assignmentId = this.assignment.id ?? null;
 
 
@@ -62,12 +63,29 @@ export class TaskComponent implements OnInit {
   }
 
   /**
+   * open the delete confirmation popup
+   */
+  confirmDeleteTask() {
+    this.showConfirmDelete = true;
+    document.addEventListener('keydown', this.handleEscapeKey);
+  }
+
+  /**
+   * close the delete confirmation popup
+   */
+  cancelDelete(): void {
+    this.showConfirmDelete = false;
+  }
+
+  /**
    * remove the task from the list
    */
   async removeTask() {
     try {
       this.assignmentService.removeTask(this.assignment.id);
       this.taskRemoved.emit(this.assignment.id as string);
+      this.showConfirmDelete = false;
+      document.removeEventListener('keydown', this.handleEscapeKey);
     } catch (error) {
       console.error('Error removing task: ', error);
     }
@@ -105,7 +123,12 @@ export class TaskComponent implements OnInit {
    */
   private handleEscapeKey = (event: KeyboardEvent): void => {
     if (event.key === 'Escape') {
-      this.closePopup();
+      if (this.showPopup) {
+        this.closePopup();
+      }
+      if (this.showConfirmDelete) {
+        this.cancelDelete();
+      }
     }
   }
 
@@ -114,6 +137,11 @@ export class TaskComponent implements OnInit {
    * @param event
    */
   handleBackdropClick(event: Event): void {
-    this.closePopup();
+    if (this.showPopup) {
+      this.closePopup();
+    }
+    if (this.showConfirmDelete) {
+      this.cancelDelete();
+    }
   }
 }

--- a/src/fe-app/src/app/notifications/notifications.component.spec.ts
+++ b/src/fe-app/src/app/notifications/notifications.component.spec.ts
@@ -54,7 +54,6 @@ describe('NotificationsComponent', () => {
   });
 
   it('should clear notifications when clearNotifications() is called', async () => {
-    spyOn(window, 'confirm').and.returnValue(true);
     await component.clearNotifications();
     fixture.detectChanges();
 

--- a/src/fe-app/src/app/notifications/notifications.component.ts
+++ b/src/fe-app/src/app/notifications/notifications.component.ts
@@ -31,11 +31,6 @@ export class NotificationsComponent implements OnInit{
    * clears all notifications for the user
    */
   async clearNotifications() {
-    if(!this.notifications || this.notifications.length === 0) {
-      alert('No notifications to be cleared');
-      return;
-    }
-
     try {
       await this.settingsService.clearNotifications(this.userId);
     } catch {

--- a/src/fe-app/src/app/settings/settings.component.spec.ts
+++ b/src/fe-app/src/app/settings/settings.component.spec.ts
@@ -49,19 +49,7 @@ describe('SettingsComponent', () => {
     expect(signOutButton).toBeTruthy();
   });
 
-  it('should not call loginService.signout when signout() is invoked on click', async () => {
-    spyOn(window, 'confirm').and.returnValue(false);
-
-    await component.handleSignout();
-
-    expect(mockLoginService.signOut).not.toHaveBeenCalled();
-    expect(mockRouter.navigate).not.toHaveBeenCalled();
-    expect(mockHeartbeatService.stopHeartbeat).not.toHaveBeenCalled();
-    expect(mockAssignmentService.reset).not.toHaveBeenCalled();
-  });
-
   it('should handle signout flow correctly', async () => {
-    spyOn(window, 'confirm').and.returnValue(true);
     spyOn(component.onSignout, 'emit');
     mockLoginService.getUserId.and.returnValue(null);
 

--- a/src/fe-app/src/app/settings/settings.component.ts
+++ b/src/fe-app/src/app/settings/settings.component.ts
@@ -37,7 +37,7 @@ export class SettingsComponent {
   }
 
   async saveAllSettings() {
-    
+
     if (!this.profileSettings.getProfileValidator()) {
       this.saveMessage = "Error saving password: ensure fields are valid";
       this.saveSuccess = false;
@@ -69,16 +69,12 @@ export class SettingsComponent {
   }
 
   handleSignout() {
-    if(confirm('Are you sure?')) {
-      this.onSignout.emit(); // Emit event to parent component
-      this.loginService.signOut();
-      if (!this.loginService.getUserId()) {
-        this.router.navigate(['/']);
-        this.heartbeatService.stopHeartbeat();
-      }
-      this.assignmentService.reset();  // Reset assignment service so assignments are not transferred across logins
-      } else {
-        return;
-      }
+    this.onSignout.emit(); // Emit event to parent component
+    this.loginService.signOut();
+    if (!this.loginService.getUserId()) {
+      this.router.navigate(['/']);
+      this.heartbeatService.stopHeartbeat();
     }
-}
+    this.assignmentService.reset();  // Reset assignment service so assignments are not transferred across logins
+    }
+  }


### PR DESCRIPTION
This PR removes all instances of the alert() and confirm() dialogs and replaces them with on screen output. Additionally notifies a user of a duplicate assignment and when adding another when a task was added successfully. Open to any styling changes of the output messages. Can be seen in login and add and edit task. 