### PR TITLE
Replace Generic Settings Save Error

### DIFF
--- a/src/fe-app/src/app/settings/settings.component.html
+++ b/src/fe-app/src/app/settings/settings.component.html
@@ -5,7 +5,7 @@
             <app-profile-settings></app-profile-settings>
             <app-notification-settings></app-notification-settings>
             <div class="sidebar-buttons">
-                <button (click)="saveAllSettings()" style = "font-size: 20px;">Save Settings</button>
+                <button (click)="saveAllSettings()" style="font-size: 20px;" [disabled]="!this.canSave">Save Settings</button>
                 @if (this.saveMessage != "") {
                     <p [class]="this.getMessageStyle()">{{ this.saveMessage }}</p>
                 }

--- a/src/fe-app/src/app/settings/settings.component.ts
+++ b/src/fe-app/src/app/settings/settings.component.ts
@@ -23,12 +23,20 @@ export class SettingsComponent {
   saveMessage: string = "";
   saveSuccess: boolean = false;
 
+  canSave: boolean = true;
+
   @ViewChild(ProfileSettingsComponent) profileSettings!: ProfileSettingsComponent;
   @ViewChild(NotificationSettingsComponent) notificationSettings !: NotificationSettingsComponent;
 
   @Output() onSignout = new EventEmitter<void>(); // EventEmitter to notify parent
 
   constructor(private cdr: ChangeDetectorRef) {}
+
+  ngAfterViewInit() {
+    this.profileSettings.profileForm.statusChanges.subscribe(status => {
+      this.canSave = (status === "VALID");
+    })
+  }
 
   getMessageStyle() {
     if (this.saveSuccess)

--- a/src/fe-app/src/app/settings/settings.component.ts
+++ b/src/fe-app/src/app/settings/settings.component.ts
@@ -45,13 +45,8 @@ export class SettingsComponent {
   }
 
   async saveAllSettings() {
-    
-    if (!this.profileSettings.getProfileValidator()) {
-      this.saveMessage = "Error saving password: ensure fields are valid";
-      this.saveSuccess = false;
-      this.cdr.detectChanges();
+    if (!this.profileSettings.getProfileValidator())
       return
-    }
 
     try {
       await this.profileSettings.saveProfile();


### PR DESCRIPTION
Removes the generic error response that is given when the user attempts to save settings with very obvious issues with the settings save button being properly disabled visually, as it was in the old settings layout.

Closes #508 