### PR TITLE
Add Loading Screen To Task List, Calendar, and Grades Pages

### DIFF
--- a/src/fe-app/src/app/main/calendar/calendar.component.css
+++ b/src/fe-app/src/app/main/calendar/calendar.component.css
@@ -173,3 +173,26 @@ p {
 .description, .course{
     font-weight: bold;
 }
+
+.loader-container {
+    width: 100%;
+    height: 100%;
+}
+.loader {
+    width: 50px;
+    padding: 8px;
+    margin: auto;
+    margin-top: 20vh;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    background: #c30000;
+    --_m: 
+      conic-gradient(#0000 10%,#000),
+      linear-gradient(#000 0 0) content-box;
+    -webkit-mask: var(--_m);
+            mask: var(--_m);
+    -webkit-mask-composite: source-out;
+            mask-composite: subtract;
+    animation: l3 1s infinite linear;
+}
+@keyframes l3 {to{transform: rotate(1turn)}}

--- a/src/fe-app/src/app/main/calendar/calendar.component.html
+++ b/src/fe-app/src/app/main/calendar/calendar.component.html
@@ -30,31 +30,43 @@
         }
         </div>
     </div>
-    <div class="calendar-content">
-    @for (dayAssignments of this.weekAssignments; track this.weekAssignments.length) {
-        <div class="calendar-column">
-        @for (assignment of dayAssignments; track assignment.id) {
-            @if (this.courseService.getSelectIndex() === -1 || assignment.courseId === this.courses[this.courseService.getSelectIndex()].id) {
-                <div class="calendar-item" [style]="this.getStyleColorByID(assignment.courseId)" (click)="this.openPopup(assignment)">
-                    <h3>{{ assignment.title }}</h3>
-                    @if (this.checkPastDue(assignment)) {
-                        <p class="urgent">{{ assignment.availability.adaptiveRelease.end.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true }) }}</p>
-                        <img class="item-icon" src="images/urgent.png" />
-                    }
-                    @else {
-                        <p>{{ assignment.availability.adaptiveRelease.end.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true }) }}</p>
-                    }
+    @defer {
+        <div class="calendar-content">
+        @for (dayAssignments of this.weekAssignments; track this.weekAssignments.length) {
+            <div class="calendar-column">
+            @for (assignment of dayAssignments; track assignment.id) {
+                @if (this.courseService.getSelectIndex() === -1 || assignment.courseId === this.courses[this.courseService.getSelectIndex()].id) {
+                    <div class="calendar-item" [style]="this.getStyleColorByID(assignment.courseId)" (click)="this.openPopup(assignment)">
+                        <h3>{{ assignment.title }}</h3>
+                        @if (this.checkPastDue(assignment)) {
+                            <p class="urgent">{{ assignment.availability.adaptiveRelease.end.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true }) }}</p>
+                            <img class="item-icon" src="images/urgent.png" />
+                        }
+                        @else {
+                            <p>{{ assignment.availability.adaptiveRelease.end.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true }) }}</p>
+                        }
 
-                    @if (assignment.complete) {
-                        <img class="item-icon" src="images/checkmark.png">
-                    }
-                </div>
+                        @if (assignment.complete) {
+                            <img class="item-icon" src="images/checkmark.png">
+                        }
+                    </div>
+                }
             }
+            </div>
         }
         </div>
     }
+    @placeholder (minimum 0.5s) {
+        <div class="loader-container">
+            <div class="loader"></div>
+        </div>
+    }
+    @loading (minimum 0.5s) {
+        <div class="loader-container">
+            <div class="loader"></div>
+        </div>
+    }
 </div>
-
 <!-- Assignment popup, not part of base page -->
 @if (this.showPopup) {
     <div class="popup-modal" (click)="handleBackdropClick()">

--- a/src/fe-app/src/app/main/grades/grades.component.css
+++ b/src/fe-app/src/app/main/grades/grades.component.css
@@ -184,3 +184,26 @@ input[readonly] {
   outline: none;
   box-shadow: none;
 }
+
+.loader-container {
+  width: 100%;
+  height: 100%;
+}
+.loader {
+  width: 50px;
+  padding: 8px;
+  margin: auto;
+  margin-top: 25vh;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: #c30000;
+  --_m: 
+    conic-gradient(#0000 10%,#000),
+    linear-gradient(#000 0 0) content-box;
+  -webkit-mask: var(--_m);
+          mask: var(--_m);
+  -webkit-mask-composite: source-out;
+          mask-composite: subtract;
+  animation: l3 1s infinite linear;
+}
+@keyframes l3 {to{transform: rotate(1turn)}}

--- a/src/fe-app/src/app/main/grades/grades.component.html
+++ b/src/fe-app/src/app/main/grades/grades.component.html
@@ -5,31 +5,43 @@
     <div class="header-column">GRADE</div>
     <div class="header-column">LETTER</div>
   </div>
-  <div class="assignment-container">
-    @for (grade of this.grades; track grade.id) {
-      @if (this.courseService.getSelectIndex() === -1 || grade.courseId === this.courses[this.courseService.getSelectIndex()].id) {
-        <div class="assignment-row">
-        <div class="assignment-column">{{ this.getCourseNameByID(grade.courseId) }}</div>
-        <div class="assignment-column">{{ this.getAssignmentTitleByID(grade.assignmentId) }}</div>
-          <div class="assignment-column">
-            <form [formGroup]="updateGradeForm" (ngSubmit)="setGrade(grade.id)">
-              @if (grade.id !== undefined) {
-                <input
-                  id="grade"
-                  type="number"
-                  [formControlName]="grade.id || ''"
-                  [placeholder]="!getAssignmentByID(grade.assignmentId)?.userCreated ? '' : (grade.percent === -1 ? 'Enter' : '')"
-                  [value]="grade.percent === -1 ? '' : grade.percent"
-                  (blur)="setGradeOnEvent($event, grade.id)"
-                  (keydown.enter)="setGradeOnEvent($event, grade.id)"
-                  [readonly]="!getAssignmentByID(grade.assignmentId)?.userCreated">
-              }
-            </form>
-          </div>
-          <div class="assignment-column">{{ this.displayGradeChar(grade) }}</div>
-          </div>
-        <!--<div id = "line" style =   "border-bottom: 3px solid #949494; width: 95%; justify-self: center;" > </div>-->
+  @defer {
+    <div class="assignment-container">
+      @for (grade of this.grades; track grade.id) {
+        @if (this.courseService.getSelectIndex() === -1 || grade.courseId === this.courses[this.courseService.getSelectIndex()].id) {
+          <div class="assignment-row">
+          <div class="assignment-column">{{ this.getCourseNameByID(grade.courseId) }}</div>
+          <div class="assignment-column">{{ this.getAssignmentTitleByID(grade.assignmentId) }}</div>
+            <div class="assignment-column">
+              <form [formGroup]="updateGradeForm" (ngSubmit)="setGrade(grade.id)">
+                @if (grade.id !== undefined) {
+                  <input
+                    id="grade"
+                    type="number"
+                    [formControlName]="grade.id || ''"
+                    [placeholder]="!getAssignmentByID(grade.assignmentId)?.userCreated ? '' : (grade.percent === -1 ? 'Enter' : '')"
+                    [value]="grade.percent === -1 ? '' : grade.percent"
+                    (blur)="setGradeOnEvent($event, grade.id)"
+                    (keydown.enter)="setGradeOnEvent($event, grade.id)"
+                    [readonly]="!getAssignmentByID(grade.assignmentId)?.userCreated">
+                }
+              </form>
+            </div>
+            <div class="assignment-column">{{ this.displayGradeChar(grade) }}</div>
+            </div>
+          <!--<div id = "line" style =   "border-bottom: 3px solid #949494; width: 95%; justify-self: center;" > </div>-->
+        }
       }
-    }
-  </div>
+    </div>
+  }
+  @placeholder (minimum 0.5s) {
+    <div class="loader-container">
+      <div class="loader"></div>
+    </div>
+  }
+  @loading (minimum 0.5s) {
+    <div class="loader-container">
+      <div class="loader"></div>
+    </div>
+  }
 </div>

--- a/src/fe-app/src/app/main/grades/grades.component.spec.ts
+++ b/src/fe-app/src/app/main/grades/grades.component.spec.ts
@@ -115,7 +115,7 @@ describe('GradesComponent', () => {
     const invalidCourseName = component.getCourseNameByID('3');
 
     expect(courseName).toBe('Course 1');
-    expect(invalidCourseName).toBe('unknown');
+    expect(invalidCourseName).toBe('');
   });
 
   it('should return assignment title by ID', () => {

--- a/src/fe-app/src/app/main/grades/grades.component.ts
+++ b/src/fe-app/src/app/main/grades/grades.component.ts
@@ -61,7 +61,7 @@ export class GradesComponent {
   /**
    * Iterates over the user's courses and returns the name of the course matching the given ID.
    * @param id The ID of a course.
-   * @returns The name of the course, or "unknown" if not found.
+   * @returns The name of the course, or "" if not found.
    */
   getCourseNameByID(id: string): string {
     //console.log("SEARCHING COURSES ARRAY OF SIZE " + this.courses.length)
@@ -69,7 +69,7 @@ export class GradesComponent {
       if (course.id === id)
         return course.name.split('-')[0];
     }
-    return  "unknown";
+    return  "";
   }
 
   /**

--- a/src/fe-app/src/app/main/main.component.css
+++ b/src/fe-app/src/app/main/main.component.css
@@ -79,9 +79,3 @@ a.active-icon img {
 router-outlet {
   display: contents;
 }
-
-
-
-
-
-  

--- a/src/fe-app/src/app/main/task-list/task-list.component.css
+++ b/src/fe-app/src/app/main/task-list/task-list.component.css
@@ -56,3 +56,26 @@ app-task-list {
 .faded {
     opacity: 0.6;
 }
+
+.loader-container {
+    width: 100%;
+    height: 100%;
+}
+.loader {
+    width: 50px;
+    padding: 8px;
+    margin: auto;
+    margin-top: 25vh;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    background: #c30000;
+    --_m: 
+      conic-gradient(#0000 10%,#000),
+      linear-gradient(#000 0 0) content-box;
+    -webkit-mask: var(--_m);
+            mask: var(--_m);
+    -webkit-mask-composite: source-out;
+            mask-composite: subtract;
+    animation: l3 1s infinite linear;
+}
+@keyframes l3 {to{transform: rotate(1turn)}}

--- a/src/fe-app/src/app/main/task-list/task-list.component.html
+++ b/src/fe-app/src/app/main/task-list/task-list.component.html
@@ -49,17 +49,28 @@
         <p>MODIFY</p>
       </div>
   </div>
-  <div class="assignment-container">
-      @for (assignment of this.assignments[this.getIndex()]; track assignment.id) {
-          @if (this.courseService.getSelectIndex() === -1 || assignment.courseId === this.courses[this.courseService.getSelectIndex()].id) {
-              <app-task
-              [assignment]="assignment"
-              [courseName]="this.getCourseNameByID(assignment.courseId)"
-              (taskRemoved)="onTaskRemoved($event)"
-              (taskUpdated)="onTaskUpdated($event)"
-              />
-          }
-      }
-  </div>
-
+  @defer {
+    <div class="assignment-container">
+        @for (assignment of this.assignments[this.getIndex()]; track assignment.id) {
+            @if (this.courseService.getSelectIndex() === -1 || assignment.courseId === this.courses[this.courseService.getSelectIndex()].id) {
+                <app-task
+                [assignment]="assignment"
+                [courseName]="this.getCourseNameByID(assignment.courseId)"
+                (taskRemoved)="onTaskRemoved($event)"
+                (taskUpdated)="onTaskUpdated($event)"
+                />
+            }
+        }
+    </div>
+  }
+  @placeholder (minimum 0.5s) {
+    <div class="loader-container">
+        <div class="loader"></div>
+    </div>
+  }
+  @loading (minimum 0.5s) {
+    <div class="loader-container">
+        <div class="loader"></div>
+    </div>
+  }
 </div>


### PR DESCRIPTION
Implements a loading screen for the above components to avoid the user being able to see content loading in. This is not actually based on the content itself loading in, as I could not find a way to reliably check for this (I tried ngAfterViewInit, checking if the entire app was stable, creating a variable to check myself, etc) and all of these checks fired prematurely and still allowed the user to see content loading in. Because of this, I just added a half-second minimum loading time, which seems to cover all bases reliably without being too intrusive.

Note: HMR introduced in Angular 19 seems to interfere with @defer blocks. When running locally, use either --no-hmr or --configuration=production to fix this.

Closes #509